### PR TITLE
Adding PINGREQ implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
+authors = ["Y. T. Chung <zonyitoo@gmail.com>"]
 name = "mqtt"
 version = "0.1.0"
-authors = ["Y. T. Chung <zonyitoo@gmail.com>"]
-
-[lib]
-name = "mqtt"
 
 [dependencies]
 byteorder = "^0.3.13"
@@ -12,6 +9,10 @@ log = "^0.3.2"
 regex = "^0.1.41"
 
 [dev-dependencies]
-env_logger = "^0.3.1"
 clap = "^1.4.0"
+env_logger = "^0.3.1"
 uuid = "^0.1.17"
+time = "*"
+
+[lib]
+name = "mqtt"

--- a/examples/sub-client.rs
+++ b/examples/sub-client.rs
@@ -4,6 +4,7 @@ extern crate log;
 extern crate env_logger;
 extern crate clap;
 extern crate uuid;
+extern crate time;
 
 use std::net::TcpStream;
 use std::io::Write;
@@ -17,6 +18,9 @@ use mqtt::{Encodable, Decodable, QualityOfService};
 use mqtt::packet::*;
 use mqtt::control::variable_header::ConnectReturnCode;
 use mqtt::TopicFilter;
+
+use std::time::Duration;
+use std::thread;
 
 fn generate_client_id() -> String {
     format!("/MQTT/rust/{}", Uuid::new_v4().to_simple_string())
@@ -71,6 +75,8 @@ fn main() {
                })
                .collect();
 
+    let keep_alive = 10;
+
     print!("Connecting to {:?} ... ", server_addr);
     let mut stream = TcpStream::connect(server_addr).unwrap();
     println!("Connected!");
@@ -78,6 +84,7 @@ fn main() {
     println!("Client identifier {:?}", client_id);
     let mut conn = ConnectPacket::new("MQTT".to_owned(), client_id.to_owned());
     conn.set_clean_session(true);
+    conn.set_keep_alive(keep_alive);
     let mut buf = Vec::new();
     conn.encode(&mut buf).unwrap();
     stream.write_all(&buf[..]).unwrap();
@@ -120,6 +127,28 @@ fn main() {
         }
     }
 
+    let mut stream_clone = stream.try_clone().unwrap();
+    thread::spawn(move || {
+        let mut last_ping_time = 0;
+        let mut next_ping_time = last_ping_time + (keep_alive as f32 * 0.9) as i64;
+        loop {
+            let current_timestamp = time::get_time().sec;
+            if keep_alive > 0 && current_timestamp >= next_ping_time {
+                println!("Sending PINGREQ to broker");
+
+                let pingreq_packet = PingreqPacket::new();
+
+                let mut buf = Vec::new();
+                pingreq_packet.encode(&mut buf).unwrap();
+                stream_clone.write_all(&buf[..]).unwrap();
+
+                last_ping_time = current_timestamp;
+                next_ping_time = last_ping_time + (keep_alive as f32 * 0.9) as i64;
+                thread::sleep(Duration::new((keep_alive / 2) as u64, 0));
+            }
+        }
+    });
+
     loop {
         let packet = match VariablePacket::decode(&mut stream) {
             Ok(pk) => pk,
@@ -131,10 +160,8 @@ fn main() {
         trace!("PACKET {:?}", packet);
 
         match &packet {
-            &VariablePacket::PingreqPacket(..) => {
-                let pingresp = PingrespPacket::new();
-                info!("Sending Ping response {:?}", pingresp);
-                pingresp.encode(&mut stream).unwrap();
+            &VariablePacket::PingrespPacket(..) => {
+                println!("Receiving PINGRESP from broker ..");
             }
             &VariablePacket::PublishPacket(ref publ) => {
                 let msg = match str::from_utf8(&publ.payload()[..]) {


### PR DESCRIPTION
Here is an implementation of sub-client with `keep_alive` time. Client sends **PINGREQ** to broker in a separate thread and broker responds to it with **PINGRESP**. If you comment out the PINGREQ thread, broker will disconnect the client after `keep_alive` time.

Would you like to merge this? Let me know if there are any concerns.