### PR TITLE
Change example argument name from HOST to SERVER

### DIFF
--- a/examples/pub-client.rs
+++ b/examples/pub-client.rs
@@ -27,12 +27,12 @@ fn main() {
 
     let matches = App::new("sub-client")
                       .author("Y. T. Chung <zonyitoo@gmail.com>")
-                      .arg(Arg::with_name("HOST")
-                               .short("h")
-                               .long("host")
+                      .arg(Arg::with_name("SERVER")
+                               .short("S")
+                               .long("server")
                                .takes_value(true)
                                .required(true)
-                               .help("MQTT host"))
+                               .help("MQTT server address (host:port)"))
                       .arg(Arg::with_name("SUBSCRIBE")
                                .short("s")
                                .long("subscribe")
@@ -57,7 +57,7 @@ fn main() {
                                .help("Client identifier"))
                       .get_matches();
 
-    let server_addr = matches.value_of("HOST").unwrap();
+    let server_addr = matches.value_of("SERVER").unwrap();
     let client_id = matches.value_of("CLIENT_ID")
                            .map(|x| x.to_owned())
                            .unwrap_or_else(generate_client_id);

--- a/examples/sub-client.rs
+++ b/examples/sub-client.rs
@@ -31,12 +31,12 @@ fn main() {
 
     let matches = App::new("sub-client")
                       .author("Y. T. Chung <zonyitoo@gmail.com>")
-                      .arg(Arg::with_name("HOST")
-                               .short("h")
-                               .long("host")
+                      .arg(Arg::with_name("SERVER")
+                               .short("S")
+                               .long("server")
                                .takes_value(true)
                                .required(true)
-                               .help("MQTT host"))
+                               .help("MQTT server address (host:port)"))
                       .arg(Arg::with_name("SUBSCRIBE")
                                .short("s")
                                .long("subscribe")
@@ -61,7 +61,7 @@ fn main() {
                                .help("Client identifier"))
                       .get_matches();
 
-    let server_addr = matches.value_of("HOST").unwrap();
+    let server_addr = matches.value_of("SERVER").unwrap();
     let client_id = matches.value_of("CLIENT_ID")
                            .map(|x| x.to_owned())
                            .unwrap_or_else(generate_client_id);


### PR DESCRIPTION
Because of this:
```
xxx/mqtt-rs $ cargo run --example pub-client -- -h test.mosquitto.org -s abc
     Running `target/debug/examples/pub-client -h test.mosquitto.org -s abc`
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error { repr: Custom(Custom { kind: InvalidInput, error: StringError("invalid socket address") }) }', ../src/libcore/result.rs:788
note: Run with `RUST_BACKTRACE=1` for a backtrace.
Connecting to "test.mosquitto.org" ... error: Process didn't exit successfully: `target/debug/examples/pub-client -h test.mosquitto.org -s abc` (exit code: 101)
```