### PR TITLE
Will message can be any binary data

### DIFF
--- a/src/packet/connect.rs
+++ b/src/packet/connect.rs
@@ -58,7 +58,7 @@ impl ConnectPacket {
         self.fixed_header.remaining_length = self.calculate_remaining_length();
     }
 
-    pub fn set_will(&mut self, topic_message: Option<(TopicName, String)>) {
+    pub fn set_will(&mut self, topic_message: Option<(TopicName, Vec<u8>)>) {
         self.flags.will_flag = topic_message.is_some();
 
         match topic_message {
@@ -107,7 +107,7 @@ impl ConnectPacket {
         self.payload.password.as_ref().map(|x| &x[..])
     }
 
-    pub fn will(&self) -> Option<(&str, &str)> {
+    pub fn will(&self) -> Option<(&str, &Vec<u8>)> {
         self.payload
             .will_topic
             .as_ref()
@@ -116,7 +116,6 @@ impl ConnectPacket {
                 self.payload
                     .will_message
                     .as_ref()
-                    .map(|x| &x[..])
                     .map(|msg| (topic, msg))
             })
     }
@@ -190,7 +189,7 @@ impl<'a> Packet<'a> for ConnectPacket {
 pub struct ConnectPacketPayload {
     client_identifier: String,
     will_topic: Option<TopicName>,
-    will_message: Option<String>,
+    will_message: Option<Vec<u8>>,
     user_name: Option<String>,
     password: Option<String>,
 }
@@ -324,6 +323,12 @@ impl Error for ConnectPacketPayloadError {
             &ConnectPacketPayloadError::StringEncodeError(ref err) => Some(err),
             &ConnectPacketPayloadError::TopicNameError(ref err) => Some(err),
         }
+    }
+}
+
+impl From<io::Error> for ConnectPacketPayloadError {
+    fn from(err: io::Error) -> ConnectPacketPayloadError {
+        ConnectPacketPayloadError::IoError(err)
     }
 }
 


### PR DESCRIPTION
Spec: http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html
### Quote from: 3.1.3.3 Will Message 
> If the Will Flag is set to 1 the Will Message is the next field in the payload. The Will Message defines the Application Message that is to be published to the Will Topic as described in Section 3.1.2.5. This field consists of a two byte length followed by the payload for **the Will Message expressed as a sequence of zero or more bytes**. The length gives the number of bytes in the data that follows and does not include the 2 bytes taken up by the length itself.

Key sentence: **the Will Message expressed as a sequence of zero or more bytes**