### PR TITLE
Encoding raw bytes also adds length prefix

### DIFF
--- a/src/encodable.rs
+++ b/src/encodable.rs
@@ -44,11 +44,13 @@ impl<'a> Encodable<'a> for &'a [u8] {
     type Err = io::Error;
 
     fn encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
-        writer.write_all(self)
+        writer.write_u16::<BigEndian>(self.len() as u16)
+            .map_err(From::from)
+            .and_then(|_| writer.write_all(self))
     }
 
     fn encoded_length(&self) -> u32 {
-        self.len() as u32
+        self.len() as u32 + 2
     }
 }
 
@@ -100,12 +102,14 @@ impl<'a> Decodable<'a> for Vec<u8> {
     fn decode_with<R: Read>(reader: &mut R, length: Option<u32>) -> Result<Vec<u8>, io::Error> {
         match length {
             Some(length) => {
+                try!(reader.read_u16::<BigEndian>()); //Throw away the initial bytes specifying length
                 let mut buf = Vec::with_capacity(length as usize);
                 try!(reader.take(length as u64).read_to_end(&mut buf));
                 Ok(buf)
             },
             None => {
-                let mut buf = Vec::new();
+                let length = try!(reader.read_u16::<BigEndian>());
+                let mut buf = Vec::with_capacity(length as usize);
                 try!(reader.read_to_end(&mut buf));
                 Ok(buf)
             }


### PR DESCRIPTION
When working with some binary MQTT message formats, I noticed I would get malformed packets if I set a `Vec<u8>` last will. Looks like it wasn't getting encoded with a prefixed byte pair specifying the length of the data, whereas the string formats were. I updated the encode/decode methods for `&[u8]`/`Vec<u8>` to add the length prefix (and now everything works again! 😄 ).