### PR TITLE
Fix topic name validation regex

### DIFF
--- a/src/topic_name.rs
+++ b/src/topic_name.rs
@@ -12,7 +12,7 @@ use regex::Regex;
 use encodable::StringEncodeError;
 use {Encodable, Decodable};
 
-const TOPIC_NAME_VALIDATE_REGEX: &'static str = r"^(\$?[^/\$]+)?(/[^/\$]*)*$";
+const TOPIC_NAME_VALIDATE_REGEX: &'static str = r"^[^#+]+$";
 
 lazy_static! {
     static ref TOPIC_NAME_VALIDATOR: Regex = Regex::new(TOPIC_NAME_VALIDATE_REGEX).unwrap();


### PR DESCRIPTION
The current regex fails on some of my topic names. It is not standard-conforming as it forbids `$` within topic names (which is perfectly valid) and allows `+` and `#` (which are not).