### PR TITLE
Convenience impls

### DIFF
--- a/src/packet/publish.rs
+++ b/src/packet/publish.rs
@@ -7,6 +7,7 @@ use control::variable_header::PacketIdentifier;
 use packet::{Packet, PacketError};
 use topic_name::TopicName;
 use {Encodable, Decodable};
+use qos::QualityOfService;
 
 /// QoS with identifier pairs
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Copy, Clone)]
@@ -14,6 +15,16 @@ pub enum QoSWithPacketIdentifier {
     Level0,
     Level1(u16),
     Level2(u16),
+}
+
+impl QoSWithPacketIdentifier {
+    pub fn new(qos: QualityOfService, id: u16) -> QoSWithPacketIdentifier {
+        match (qos, id) {
+            (QualityOfService::Level0, _) => QoSWithPacketIdentifier::Level0,
+            (QualityOfService::Level1, id) => QoSWithPacketIdentifier::Level1(id),
+            (QualityOfService::Level2, id) => QoSWithPacketIdentifier::Level2(id),
+        }
+    }
 }
 
 /// `PUBLISH` packet

--- a/src/qos.rs
+++ b/src/qos.rs
@@ -1,9 +1,43 @@
 //! QoS (Quality of Services)
 
+use packet::publish::QoSWithPacketIdentifier;
+
 #[repr(u8)]
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Copy, Clone)]
 pub enum QualityOfService {
     Level0 = 0,
     Level1 = 1,
     Level2 = 2,
+}
+
+impl From<QoSWithPacketIdentifier> for QualityOfService {
+    fn from(qos: QoSWithPacketIdentifier) -> Self {
+        match qos {
+            QoSWithPacketIdentifier::Level0 => QualityOfService::Level0,
+            QoSWithPacketIdentifier::Level1(_) => QualityOfService::Level1,
+            QoSWithPacketIdentifier::Level2(_) => QualityOfService::Level2,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::cmp::min;
+
+    #[test]
+    fn min_qos() {
+        let q1 = QoSWithPacketIdentifier::Level1(0).into();
+        let q2 = QualityOfService::Level2;
+        assert_eq!(min(q1, q2), q1);
+
+        let q1 = QoSWithPacketIdentifier::Level0.into();
+        let q2 = QualityOfService::Level2;
+        assert_eq!(min(q1, q2), q1);
+
+        let q1 = QoSWithPacketIdentifier::Level2(0).into();
+        let q2 = QualityOfService::Level1;
+        assert_eq!(min(q1, q2), q2);
+    }
+
 }

--- a/src/topic_name.rs
+++ b/src/topic_name.rs
@@ -26,7 +26,7 @@ fn is_invalid_topic_name(topic_name: &str) -> bool {
 /// Topic name
 ///
 /// http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718106
-#[derive(Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone, Hash)]
 pub struct TopicName(String);
 
 impl TopicName {


### PR DESCRIPTION
Hi.

This PR adds 2 features:

1. Hash deriving for TopicName, that will allow to use it as a hash-table key. Usable for storing subscriptions.
2. Conversions between QualityOfService and QoSWithPacketIdentifier, giving easier comparison when deciding topic's minimal QoS (see included test).