### PR TITLE
Usability improvements, and tokio support for parsing packets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ byteorder = "1.0"
 log = "0.3"
 regex = "0.2"
 lazy_static = "0.2"
+tokio-io = "0.1.7"
+futures = "0.1.22"
 
 [dev-dependencies]
 clap = "2.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ clap = "2.23"
 env_logger = "0.4"
 uuid = { version = "0.4", features = ["v4"] }
 time = "0.1"
+tokio = "0.1.7"
 
 [lib]
 name = "mqtt"

--- a/examples/pub-client.rs
+++ b/examples/pub-client.rs
@@ -5,6 +5,7 @@ extern crate env_logger;
 extern crate clap;
 extern crate uuid;
 
+use std::env;
 use std::io::{self, Write};
 use std::net::TcpStream;
 use std::thread;
@@ -23,6 +24,11 @@ fn generate_client_id() -> String {
 }
 
 fn main() {
+    // configure logging
+    env::set_var(
+        "RUST_LOG",
+        env::var_os("RUST_LOG").unwrap_or_else(|| "info".into()),
+    );
     env_logger::init().unwrap();
 
     let matches = App::new("sub-client")
@@ -67,11 +73,11 @@ fn main() {
                .map(|c| (TopicFilter::new(c.to_string()).unwrap(), QualityOfService::Level0))
                .collect();
 
-    print!("Connecting to {:?} ... ", server_addr);
+    info!("Connecting to {:?} ... ", server_addr);
     let mut stream = TcpStream::connect(server_addr).unwrap();
-    println!("Connected!");
+    info!("Connected!");
 
-    println!("Client identifier {:?}", client_id);
+    info!("Client identifier {:?}", client_id);
     let mut conn = ConnectPacket::new("MQTT", client_id);
     conn.set_clean_session(true);
     let mut buf = Vec::new();
@@ -85,7 +91,7 @@ fn main() {
         panic!("Failed to connect to server, return code {:?}", connack.connect_return_code());
     }
 
-    println!("Applying channel filters {:?} ...", channel_filters);
+    info!("Applying channel filters {:?} ...", channel_filters);
     let sub = SubscribePacket::new(10, channel_filters);
     let mut buf = Vec::new();
     sub.encode(&mut buf).unwrap();

--- a/examples/sub-client-async.rs
+++ b/examples/sub-client-async.rs
@@ -1,0 +1,187 @@
+extern crate mqtt;
+#[macro_use]
+extern crate log;
+extern crate env_logger;
+extern crate clap;
+extern crate uuid;
+extern crate futures;
+extern crate tokio;
+
+use std::env;
+use std::fmt::Debug;
+use std::io::Write;
+use std::str;
+use std::net;
+use std::time::{Duration, Instant};
+
+use clap::{App, Arg};
+
+use uuid::Uuid;
+
+use futures::{Future, Stream, future};
+
+use tokio::net::TcpStream;
+use tokio::io::{self, AsyncRead};
+use tokio::timer::Interval;
+
+use mqtt::{Decodable, Encodable, QualityOfService};
+use mqtt::TopicFilter;
+use mqtt::control::variable_header::ConnectReturnCode;
+use mqtt::packet::*;
+
+fn generate_client_id() -> String {
+    format!("/MQTT/rust/{}", Uuid::new_v4().simple())
+}
+
+fn alt_drop<E: Debug>(err: E) {
+    warn!("{:?}", err);
+}
+
+fn main() {
+    // configure logging
+    env::set_var(
+        "RUST_LOG",
+        env::var_os("RUST_LOG").unwrap_or_else(|| "info".into()),
+    );
+    env_logger::init().unwrap();
+
+    let matches = App::new("sub-client")
+        .author("Y. T. Chung <zonyitoo@gmail.com>")
+        .arg(Arg::with_name("SERVER")
+                 .short("S")
+                 .long("server")
+                 .takes_value(true)
+                 .required(true)
+                 .help("MQTT server address (host:port)"))
+        .arg(Arg::with_name("SUBSCRIBE")
+                 .short("s")
+                 .long("subscribe")
+                 .takes_value(true)
+                 .multiple(true)
+                 .required(true)
+                 .help("Channel filter to subscribe"))
+        .arg(Arg::with_name("USER_NAME")
+                 .short("u")
+                 .long("username")
+                 .takes_value(true)
+                 .help("Login user name"))
+        .arg(Arg::with_name("PASSWORD")
+                 .short("p")
+                 .long("password")
+                 .takes_value(true)
+                 .help("Password"))
+        .arg(Arg::with_name("CLIENT_ID")
+                 .short("i")
+                 .long("client-identifier")
+                 .takes_value(true)
+                 .help("Client identifier"))
+        .get_matches();
+
+    let server_addr = matches.value_of("SERVER").unwrap();
+    let client_id = matches.value_of("CLIENT_ID")
+                           .map(|x| x.to_owned())
+                           .unwrap_or_else(generate_client_id);
+    let channel_filters: Vec<(TopicFilter, QualityOfService)> =
+        matches.values_of("SUBSCRIBE")
+               .unwrap()
+               .map(|c| (TopicFilter::new(c.to_string()).unwrap(), QualityOfService::Level0))
+               .collect();
+
+    let keep_alive = 10;
+
+    info!("Connecting to {:?} ... ", server_addr);
+    let mut stream = net::TcpStream::connect(server_addr).unwrap();
+    info!("Connected!");
+
+    info!("Client identifier {:?}", client_id);
+    let mut conn = ConnectPacket::new("MQTT", client_id);
+    conn.set_clean_session(true);
+    conn.set_keep_alive(keep_alive);
+    let mut buf = Vec::new();
+    conn.encode(&mut buf).unwrap();
+    stream.write_all(&buf[..]).unwrap();
+
+    let connack = ConnackPacket::decode(&mut stream).unwrap();
+    trace!("CONNACK {:?}", connack);
+
+    if connack.connect_return_code() != ConnectReturnCode::ConnectionAccepted {
+        panic!("Failed to connect to server, return code {:?}", connack.connect_return_code());
+    }
+
+    // const CHANNEL_FILTER: &'static str = "typing-speed-test.aoeu.eu";
+    info!("Applying channel filters {:?} ...", channel_filters);
+    let sub = SubscribePacket::new(10, channel_filters);
+    let mut buf = Vec::new();
+    sub.encode(&mut buf).unwrap();
+    stream.write_all(&buf[..]).unwrap();
+
+    loop {
+        let packet = match VariablePacket::decode(&mut stream) {
+            Ok(pk) => pk,
+            Err(err) => {
+                error!("Error in receiving packet {:?}", err);
+                continue;
+            }
+        };
+        trace!("PACKET {:?}", packet);
+
+        if let VariablePacket::SubackPacket(ref ack) = packet {
+            if ack.packet_identifier() != 10 {
+                panic!("SUBACK packet identifier not match");
+            }
+
+            info!("Subscribed!");
+            break;
+        }
+    }
+
+    // connection made, start the async work
+    let program = future::ok(())
+        .and_then(move |()| {
+            let stream = TcpStream::from_std(stream, &Default::default()).unwrap();
+            let (mqtt_read, mqtt_write) = stream.split();
+
+            let ping_time = Duration::new((keep_alive / 2) as u64, 0);
+            let ping_stream = Interval::new(Instant::now() + ping_time, ping_time);
+
+            let ping_sender = ping_stream.map_err(alt_drop).fold(mqtt_write, |mqtt_write, _| {
+                info!("Sending PINGREQ to broker");
+
+                let pingreq_packet = PingreqPacket::new();
+
+                let mut buf = Vec::new();
+                pingreq_packet.encode(&mut buf).unwrap();
+                io::write_all(mqtt_write, buf).map(|(mqtt_write, _buf)| mqtt_write).map_err(alt_drop)
+            });
+
+            let receiver = future::loop_fn::<_, (), _, _>(mqtt_read, |mqtt_read| {
+                VariablePacket::parse(mqtt_read)
+                    .map(|(mqtt_read, packet)| {
+                        trace!("PACKET {:?}", packet);
+
+                        match packet {
+                            VariablePacket::PingrespPacket(..) => {
+                                info!("Receiving PINGRESP from broker ..");
+                            }
+                            VariablePacket::PublishPacket(ref publ) => {
+                                let msg = match str::from_utf8(&publ.payload_ref()[..]) {
+                                    Ok(msg) => msg,
+                                    Err(err) => {
+                                        error!("Failed to decode publish message {:?}", err);
+                                        return future::Loop::Continue(mqtt_read);
+                                    }
+                                };
+                                info!("PUBLISH ({}): {}", publ.topic_name(), msg);
+                            }
+                            _ => {}
+                        }
+
+                        future::Loop::Continue(mqtt_read)
+                    })
+                }).map_err(alt_drop);
+
+            ping_sender.join(receiver).map(alt_drop)
+        });
+
+    tokio::run(program);
+}

--- a/examples/sub-client.rs
+++ b/examples/sub-client.rs
@@ -156,7 +156,7 @@ fn main() {
                 println!("Receiving PINGRESP from broker ..");
             }
             VariablePacket::PublishPacket(ref publ) => {
-                let msg = match str::from_utf8(&publ.payload()[..]) {
+                let msg = match str::from_utf8(&publ.payload_ref()[..]) {
                     Ok(msg) => msg,
                     Err(err) => {
                         error!("Failed to decode publish message {:?}", err);

--- a/src/control/fixed_header.rs
+++ b/src/control/fixed_header.rs
@@ -48,10 +48,10 @@ impl FixedHeader {
     /// Asynchronously parse a single fixed header from an AsyncRead type, such as a network
     /// socket.
     pub fn parse<A: AsyncRead>(rdr: A) -> impl Future<Item = (A, Self), Error = FixedHeaderError> {
-        async_io::read_exact(rdr, [0u8; 2])
+        async_io::read_exact(rdr, [0u8])
             .from_err()
-            .and_then(|(rdr, [type_val, cur])| {
-                future::loop_fn((rdr, u32::from(cur), 0), |(rdr, mut cur, i)| {
+            .and_then(|(rdr, [type_val])| {
+                future::loop_fn((rdr, 0, 0), |(rdr, mut cur, i)| {
                     async_io::read_exact(rdr, [0u8])
                         .from_err()
                         .and_then(move |(rdr, [byte])| {

--- a/src/control/fixed_header.rs
+++ b/src/control/fixed_header.rs
@@ -43,7 +43,7 @@ impl FixedHeader {
     }
 }
 
-impl<'a> Encodable<'a> for FixedHeader {
+impl Encodable for FixedHeader {
     type Err = FixedHeaderError;
 
     fn encode<W: Write>(&self, wr: &mut W) -> Result<(), FixedHeaderError> {
@@ -82,7 +82,7 @@ impl<'a> Encodable<'a> for FixedHeader {
     }
 }
 
-impl<'a> Decodable<'a> for FixedHeader {
+impl Decodable for FixedHeader {
     type Err = FixedHeaderError;
     type Cond = ();
 

--- a/src/control/variable_header/connect_ack_flags.rs
+++ b/src/control/variable_header/connect_ack_flags.rs
@@ -18,7 +18,7 @@ impl ConnackFlags {
     }
 }
 
-impl<'a> Encodable<'a> for ConnackFlags {
+impl Encodable for ConnackFlags {
     type Err = VariableHeaderError;
 
     fn encode<W: Write>(&self, writer: &mut W) -> Result<(), VariableHeaderError> {
@@ -31,7 +31,7 @@ impl<'a> Encodable<'a> for ConnackFlags {
     }
 }
 
-impl<'a> Decodable<'a> for ConnackFlags {
+impl Decodable for ConnackFlags {
     type Err = VariableHeaderError;
     type Cond = ();
 

--- a/src/control/variable_header/connect_flags.rs
+++ b/src/control/variable_header/connect_flags.rs
@@ -30,7 +30,7 @@ impl ConnectFlags {
     }
 }
 
-impl<'a> Encodable<'a> for ConnectFlags {
+impl Encodable for ConnectFlags {
     type Err = VariableHeaderError;
 
     #[cfg_attr(rustfmt, rustfmt_skip)]
@@ -50,7 +50,7 @@ impl<'a> Encodable<'a> for ConnectFlags {
     }
 }
 
-impl<'a> Decodable<'a> for ConnectFlags {
+impl Decodable for ConnectFlags {
     type Err = VariableHeaderError;
     type Cond = ();
 

--- a/src/control/variable_header/connect_ret_code.rs
+++ b/src/control/variable_header/connect_ret_code.rs
@@ -53,7 +53,7 @@ impl ConnectReturnCode {
     }
 }
 
-impl<'a> Encodable<'a> for ConnectReturnCode {
+impl Encodable for ConnectReturnCode {
     type Err = VariableHeaderError;
 
     fn encode<W: Write>(&self, writer: &mut W) -> Result<(), VariableHeaderError> {
@@ -65,7 +65,7 @@ impl<'a> Encodable<'a> for ConnectReturnCode {
     }
 }
 
-impl<'a> Decodable<'a> for ConnectReturnCode {
+impl Decodable for ConnectReturnCode {
     type Err = VariableHeaderError;
     type Cond = ();
 

--- a/src/control/variable_header/keep_alive.rs
+++ b/src/control/variable_header/keep_alive.rs
@@ -10,7 +10,7 @@ use control::variable_header::VariableHeaderError;
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub struct KeepAlive(pub u16);
 
-impl<'a> Encodable<'a> for KeepAlive {
+impl Encodable for KeepAlive {
     type Err = VariableHeaderError;
 
     fn encode<W: Write>(&self, writer: &mut W) -> Result<(), VariableHeaderError> {
@@ -22,7 +22,7 @@ impl<'a> Encodable<'a> for KeepAlive {
     }
 }
 
-impl<'a> Decodable<'a> for KeepAlive {
+impl Decodable for KeepAlive {
     type Err = VariableHeaderError;
     type Cond = ();
 

--- a/src/control/variable_header/packet_identifier.rs
+++ b/src/control/variable_header/packet_identifier.rs
@@ -10,7 +10,7 @@ use control::variable_header::VariableHeaderError;
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub struct PacketIdentifier(pub u16);
 
-impl<'a> Encodable<'a> for PacketIdentifier {
+impl Encodable for PacketIdentifier {
     type Err = VariableHeaderError;
 
     fn encode<W: Write>(&self, writer: &mut W) -> Result<(), VariableHeaderError> {
@@ -22,7 +22,7 @@ impl<'a> Encodable<'a> for PacketIdentifier {
     }
 }
 
-impl<'a> Decodable<'a> for PacketIdentifier {
+impl Decodable for PacketIdentifier {
     type Err = VariableHeaderError;
     type Cond = ();
 

--- a/src/control/variable_header/protocol_level.rs
+++ b/src/control/variable_header/protocol_level.rs
@@ -14,7 +14,7 @@ pub const SPEC_3_1_1: u8 = 0x04;
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub struct ProtocolLevel(pub u8);
 
-impl<'a> Encodable<'a> for ProtocolLevel {
+impl Encodable for ProtocolLevel {
     type Err = VariableHeaderError;
 
     fn encode<W: Write>(&self, writer: &mut W) -> Result<(), VariableHeaderError> {
@@ -26,7 +26,7 @@ impl<'a> Encodable<'a> for ProtocolLevel {
     }
 }
 
-impl<'a> Decodable<'a> for ProtocolLevel {
+impl Decodable for ProtocolLevel {
     type Err = VariableHeaderError;
     type Cond = ();
 

--- a/src/control/variable_header/protocol_name.rs
+++ b/src/control/variable_header/protocol_name.rs
@@ -22,7 +22,7 @@ use control::variable_header::VariableHeaderError;
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct ProtocolName(pub String);
 
-impl<'a> Encodable<'a> for ProtocolName {
+impl Encodable for ProtocolName {
     type Err = VariableHeaderError;
 
     fn encode<W: Write>(&self, writer: &mut W) -> Result<(), VariableHeaderError> {
@@ -34,7 +34,7 @@ impl<'a> Encodable<'a> for ProtocolName {
     }
 }
 
-impl<'a> Decodable<'a> for ProtocolName {
+impl Decodable for ProtocolName {
     type Err = VariableHeaderError;
     type Cond = ();
 

--- a/src/control/variable_header/topic_name.rs
+++ b/src/control/variable_header/topic_name.rs
@@ -24,7 +24,7 @@ impl Into<TopicName> for TopicNameHeader {
     }
 }
 
-impl<'a> Encodable<'a> for TopicNameHeader {
+impl Encodable for TopicNameHeader {
     type Err = VariableHeaderError;
 
     fn encode<W: Write>(&self, writer: &mut W) -> Result<(), VariableHeaderError> {
@@ -36,7 +36,7 @@ impl<'a> Encodable<'a> for TopicNameHeader {
     }
 }
 
-impl<'a> Decodable<'a> for TopicNameHeader {
+impl Decodable for TopicNameHeader {
     type Err = VariableHeaderError;
     type Cond = ();
 

--- a/src/encodable.rs
+++ b/src/encodable.rs
@@ -10,8 +10,8 @@ use std::string::FromUtf8Error;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
 /// Methods for encoding an Object to bytes according to MQTT specification
-pub trait Encodable<'a> {
-    type Err: Error + 'a;
+pub trait Encodable {
+    type Err: Error;
 
     /// Encodes to writer
     fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Self::Err>;
@@ -20,8 +20,8 @@ pub trait Encodable<'a> {
 }
 
 /// Methods for decoding bytes to an Object according to MQTT specification
-pub trait Decodable<'a>: Sized {
-    type Err: Error + 'a;
+pub trait Decodable: Sized {
+    type Err: Error;
     type Cond;
 
     /// Decodes object from reader
@@ -33,7 +33,7 @@ pub trait Decodable<'a>: Sized {
     fn decode_with<R: Read>(reader: &mut R, cond: Option<Self::Cond>) -> Result<Self, Self::Err>;
 }
 
-impl<'a> Encodable<'a> for &'a str {
+impl<'a> Encodable for &'a str {
     type Err = StringEncodeError;
 
     fn encode<W: Write>(&self, writer: &mut W) -> Result<(), StringEncodeError> {
@@ -50,7 +50,7 @@ impl<'a> Encodable<'a> for &'a str {
     }
 }
 
-impl<'a> Encodable<'a> for &'a [u8] {
+impl<'a> Encodable for &'a [u8] {
     type Err = io::Error;
 
     fn encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
@@ -62,7 +62,7 @@ impl<'a> Encodable<'a> for &'a [u8] {
     }
 }
 
-impl<'a> Encodable<'a> for String {
+impl Encodable for String {
     type Err = StringEncodeError;
 
     fn encode<W: Write>(&self, writer: &mut W) -> Result<(), StringEncodeError> {
@@ -74,7 +74,7 @@ impl<'a> Encodable<'a> for String {
     }
 }
 
-impl<'a> Decodable<'a> for String {
+impl Decodable for String {
     type Err = StringEncodeError;
     type Cond = ();
 
@@ -90,7 +90,7 @@ impl<'a> Decodable<'a> for String {
     }
 }
 
-impl<'a> Encodable<'a> for Vec<u8> {
+impl Encodable for Vec<u8> {
     type Err = io::Error;
 
     fn encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
@@ -102,7 +102,7 @@ impl<'a> Encodable<'a> for Vec<u8> {
     }
 }
 
-impl<'a> Decodable<'a> for Vec<u8> {
+impl Decodable for Vec<u8> {
     type Err = io::Error;
     type Cond = u32;
 
@@ -125,7 +125,7 @@ impl<'a> Decodable<'a> for Vec<u8> {
     }
 }
 
-impl<'a> Encodable<'a> for () {
+impl Encodable for () {
     type Err = NoError;
 
     fn encode<W: Write>(&self, _: &mut W) -> Result<(), NoError> {
@@ -137,7 +137,7 @@ impl<'a> Encodable<'a> for () {
     }
 }
 
-impl<'a> Decodable<'a> for () {
+impl Decodable for () {
     type Err = NoError;
     type Cond = ();
 
@@ -150,7 +150,7 @@ impl<'a> Decodable<'a> for () {
 #[derive(Debug, Eq, PartialEq)]
 pub struct VarBytes(pub Vec<u8>);
 
-impl<'a> Encodable<'a> for VarBytes {
+impl Encodable for VarBytes {
     type Err = io::Error;
     fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Self::Err> {
         assert!(self.0.len() <= u16::max_value() as usize);
@@ -165,7 +165,7 @@ impl<'a> Encodable<'a> for VarBytes {
     }
 }
 
-impl<'a> Decodable<'a> for VarBytes {
+impl Decodable for VarBytes {
     type Err = io::Error;
     type Cond = ();
     fn decode_with<R: Read>(reader: &mut R, _: Option<()>) -> Result<VarBytes, io::Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,8 @@ extern crate byteorder;
 extern crate regex;
 #[macro_use]
 extern crate lazy_static;
+extern crate futures;
+extern crate tokio_io;
 
 pub use self::encodable::{Decodable, Encodable};
 pub use self::qos::QualityOfService;

--- a/src/packet/connack.rs
+++ b/src/packet/connack.rs
@@ -35,7 +35,7 @@ impl ConnackPacket {
     }
 }
 
-impl<'a> Packet<'a> for ConnackPacket {
+impl Packet for ConnackPacket {
     type Payload = ();
 
     fn fixed_header(&self) -> &FixedHeader {
@@ -46,7 +46,7 @@ impl<'a> Packet<'a> for ConnackPacket {
         &self.payload
     }
 
-    fn encode_variable_headers<W: Write>(&self, writer: &mut W) -> Result<(), PacketError<'a, Self>> {
+    fn encode_variable_headers<W: Write>(&self, writer: &mut W) -> Result<(), PacketError<Self>> {
         self.flags.encode(writer)?;
         self.ret_code.encode(writer)?;
         Ok(())
@@ -56,7 +56,7 @@ impl<'a> Packet<'a> for ConnackPacket {
         self.flags.encoded_length() + self.ret_code.encoded_length()
     }
 
-    fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<'a, Self>> {
+    fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {
         let flags: ConnackFlags = Decodable::decode(reader)?;
         let code: ConnectReturnCode = Decodable::decode(reader)?;
 

--- a/src/packet/connack.rs
+++ b/src/packet/connack.rs
@@ -42,7 +42,11 @@ impl Packet for ConnackPacket {
         &self.fixed_header
     }
 
-    fn payload(&self) -> &Self::Payload {
+    fn payload(self) -> Self::Payload {
+        self.payload
+    }
+
+    fn payload_ref(&self) -> &Self::Payload {
         &self.payload
     }
 

--- a/src/packet/connect.rs
+++ b/src/packet/connect.rs
@@ -147,7 +147,7 @@ impl ConnectPacket {
     }
 }
 
-impl<'a> Packet<'a> for ConnectPacket {
+impl Packet for ConnectPacket {
     type Payload = ConnectPacketPayload;
 
     fn fixed_header(&self) -> &FixedHeader {
@@ -158,7 +158,7 @@ impl<'a> Packet<'a> for ConnectPacket {
         &self.payload
     }
 
-    fn encode_variable_headers<W: Write>(&self, writer: &mut W) -> Result<(), PacketError<'a, Self>> {
+    fn encode_variable_headers<W: Write>(&self, writer: &mut W) -> Result<(), PacketError<Self>> {
         self.protocol_name.encode(writer)?;
         self.protocol_level.encode(writer)?;
         self.flags.encode(writer)?;
@@ -172,12 +172,12 @@ impl<'a> Packet<'a> for ConnectPacket {
             self.keep_alive.encoded_length()
     }
 
-    fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<'a, Self>> {
+    fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {
         let protoname: ProtocolName = Decodable::decode(reader)?;
         let protocol_level: ProtocolLevel = Decodable::decode(reader)?;
         let flags: ConnectFlags = Decodable::decode(reader)?;
         let keep_alive: KeepAlive = Decodable::decode(reader)?;
-        let payload: ConnectPacketPayload = Decodable::decode_with(reader, Some(&flags))
+        let payload: ConnectPacketPayload = Decodable::decode_with(reader, Some(flags))
             .map_err(PacketError::PayloadError)?;
 
         Ok(ConnectPacket {
@@ -213,7 +213,7 @@ impl ConnectPacketPayload {
     }
 }
 
-impl<'a> Encodable<'a> for ConnectPacketPayload {
+impl Encodable for ConnectPacketPayload {
     type Err = ConnectPacketPayloadError;
 
     fn encode<W: Write>(&self, writer: &mut W) -> Result<(), ConnectPacketPayloadError> {
@@ -259,12 +259,12 @@ impl<'a> Encodable<'a> for ConnectPacketPayload {
     }
 }
 
-impl<'a> Decodable<'a> for ConnectPacketPayload {
+impl Decodable for ConnectPacketPayload {
     type Err = ConnectPacketPayloadError;
-    type Cond = &'a ConnectFlags;
+    type Cond = ConnectFlags;
 
     fn decode_with<R: Read>(reader: &mut R,
-                            rest: Option<&'a ConnectFlags>)
+                            rest: Option<ConnectFlags>)
                             -> Result<ConnectPacketPayload, ConnectPacketPayloadError> {
         let mut need_will_topic = false;
         let mut need_will_message = false;

--- a/src/packet/connect.rs
+++ b/src/packet/connect.rs
@@ -55,7 +55,7 @@ impl ConnectPacket {
 
     #[inline]
     fn calculate_remaining_length(&self) -> u32 {
-        self.encoded_variable_headers_length() + self.payload().encoded_length()
+        self.encoded_variable_headers_length() + self.payload_ref().encoded_length()
     }
 
     pub fn set_keep_alive(&mut self, keep_alive: u16) {
@@ -154,7 +154,11 @@ impl Packet for ConnectPacket {
         &self.fixed_header
     }
 
-    fn payload(&self) -> &ConnectPacketPayload {
+    fn payload(self) -> ConnectPacketPayload {
+        self.payload
+    }
+
+    fn payload_ref(&self) -> &ConnectPacketPayload {
         &self.payload
     }
 

--- a/src/packet/disconnect.rs
+++ b/src/packet/disconnect.rs
@@ -21,7 +21,7 @@ impl DisconnectPacket {
     }
 }
 
-impl<'a> Packet<'a> for DisconnectPacket {
+impl Packet for DisconnectPacket {
     type Payload = ();
 
     fn fixed_header(&self) -> &FixedHeader {
@@ -32,7 +32,7 @@ impl<'a> Packet<'a> for DisconnectPacket {
         &self.payload
     }
 
-    fn encode_variable_headers<W: Write>(&self, _writer: &mut W) -> Result<(), PacketError<'a, Self>> {
+    fn encode_variable_headers<W: Write>(&self, _writer: &mut W) -> Result<(), PacketError<Self>> {
         Ok(())
     }
 
@@ -40,7 +40,7 @@ impl<'a> Packet<'a> for DisconnectPacket {
         0
     }
 
-    fn decode_packet<R: Read>(_reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<'a, Self>> {
+    fn decode_packet<R: Read>(_reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {
         Ok(DisconnectPacket {
                fixed_header: fixed_header,
                payload: (),

--- a/src/packet/disconnect.rs
+++ b/src/packet/disconnect.rs
@@ -28,7 +28,11 @@ impl Packet for DisconnectPacket {
         &self.fixed_header
     }
 
-    fn payload(&self) -> &Self::Payload {
+    fn payload(self) -> Self::Payload {
+        self.payload
+    }
+
+    fn payload_ref(&self) -> &Self::Payload {
         &self.payload
     }
 

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -51,8 +51,10 @@ pub trait Packet: Sized {
 
     /// Get a `FixedHeader` of this packet
     fn fixed_header(&self) -> &FixedHeader;
-    /// Get payload
-    fn payload(&self) -> &Self::Payload;
+    /// Get the payload
+    fn payload(self) -> Self::Payload;
+    /// Get a borrow of payload
+    fn payload_ref(&self) -> &Self::Payload;
 
     /// Encode variable headers to writer
     fn encode_variable_headers<W: Write>(&self, writer: &mut W) -> Result<(), PacketError<Self>>;
@@ -69,13 +71,13 @@ impl<T: Packet + fmt::Debug> Encodable for T {
         self.fixed_header().encode(writer)?;
         self.encode_variable_headers(writer)?;
 
-        self.payload()
+        self.payload_ref()
             .encode(writer)
             .map_err(PacketError::PayloadError)
     }
 
     fn encoded_length(&self) -> u32 {
-        self.fixed_header().encoded_length() + self.encoded_variable_headers_length() + self.payload().encoded_length()
+        self.fixed_header().encoded_length() + self.encoded_variable_headers_length() + self.payload_ref().encoded_length()
     }
 }
 

--- a/src/packet/pingreq.rs
+++ b/src/packet/pingreq.rs
@@ -28,7 +28,11 @@ impl Packet for PingreqPacket {
         &self.fixed_header
     }
 
-    fn payload(&self) -> &Self::Payload {
+    fn payload(self) -> Self::Payload {
+        self.payload
+    }
+
+    fn payload_ref(&self) -> &Self::Payload {
         &self.payload
     }
 

--- a/src/packet/pingreq.rs
+++ b/src/packet/pingreq.rs
@@ -21,7 +21,7 @@ impl PingreqPacket {
     }
 }
 
-impl<'a> Packet<'a> for PingreqPacket {
+impl Packet for PingreqPacket {
     type Payload = ();
 
     fn fixed_header(&self) -> &FixedHeader {
@@ -32,7 +32,7 @@ impl<'a> Packet<'a> for PingreqPacket {
         &self.payload
     }
 
-    fn encode_variable_headers<W: Write>(&self, _writer: &mut W) -> Result<(), PacketError<'a, Self>> {
+    fn encode_variable_headers<W: Write>(&self, _writer: &mut W) -> Result<(), PacketError<Self>> {
         Ok(())
     }
 
@@ -40,7 +40,7 @@ impl<'a> Packet<'a> for PingreqPacket {
         0
     }
 
-    fn decode_packet<R: Read>(_reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<'a, Self>> {
+    fn decode_packet<R: Read>(_reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {
         Ok(PingreqPacket {
                fixed_header: fixed_header,
                payload: (),

--- a/src/packet/pingresp.rs
+++ b/src/packet/pingresp.rs
@@ -21,7 +21,7 @@ impl PingrespPacket {
     }
 }
 
-impl<'a> Packet<'a> for PingrespPacket {
+impl Packet for PingrespPacket {
     type Payload = ();
 
     fn fixed_header(&self) -> &FixedHeader {
@@ -32,7 +32,7 @@ impl<'a> Packet<'a> for PingrespPacket {
         &self.payload
     }
 
-    fn encode_variable_headers<W: Write>(&self, _writer: &mut W) -> Result<(), PacketError<'a, Self>> {
+    fn encode_variable_headers<W: Write>(&self, _writer: &mut W) -> Result<(), PacketError<Self>> {
         Ok(())
     }
 
@@ -40,7 +40,7 @@ impl<'a> Packet<'a> for PingrespPacket {
         0
     }
 
-    fn decode_packet<R: Read>(_reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<'a, Self>> {
+    fn decode_packet<R: Read>(_reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {
         Ok(PingrespPacket {
                fixed_header: fixed_header,
                payload: (),

--- a/src/packet/pingresp.rs
+++ b/src/packet/pingresp.rs
@@ -28,7 +28,11 @@ impl Packet for PingrespPacket {
         &self.fixed_header
     }
 
-    fn payload(&self) -> &Self::Payload {
+    fn payload(self) -> Self::Payload {
+        self.payload
+    }
+
+    fn payload_ref(&self) -> &Self::Payload {
         &self.payload
     }
 

--- a/src/packet/puback.rs
+++ b/src/packet/puback.rs
@@ -40,7 +40,11 @@ impl Packet for PubackPacket {
         &self.fixed_header
     }
 
-    fn payload(&self) -> &Self::Payload {
+    fn payload(self) -> Self::Payload {
+        self.payload
+    }
+
+    fn payload_ref(&self) -> &Self::Payload {
         &self.payload
     }
 

--- a/src/packet/puback.rs
+++ b/src/packet/puback.rs
@@ -33,7 +33,7 @@ impl PubackPacket {
     }
 }
 
-impl<'a> Packet<'a> for PubackPacket {
+impl Packet for PubackPacket {
     type Payload = ();
 
     fn fixed_header(&self) -> &FixedHeader {
@@ -44,7 +44,7 @@ impl<'a> Packet<'a> for PubackPacket {
         &self.payload
     }
 
-    fn encode_variable_headers<W: Write>(&self, writer: &mut W) -> Result<(), PacketError<'a, Self>> {
+    fn encode_variable_headers<W: Write>(&self, writer: &mut W) -> Result<(), PacketError<Self>> {
         self.packet_identifier.encode(writer)?;
 
         Ok(())
@@ -54,7 +54,7 @@ impl<'a> Packet<'a> for PubackPacket {
         self.packet_identifier.encoded_length()
     }
 
-    fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<'a, Self>> {
+    fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {
         let packet_identifier: PacketIdentifier = PacketIdentifier::decode(reader)?;
         Ok(PubackPacket {
                fixed_header: fixed_header,

--- a/src/packet/pubcomp.rs
+++ b/src/packet/pubcomp.rs
@@ -40,7 +40,11 @@ impl Packet for PubcompPacket {
         &self.fixed_header
     }
 
-    fn payload(&self) -> &Self::Payload {
+    fn payload(self) -> Self::Payload {
+        self.payload
+    }
+
+    fn payload_ref(&self) -> &Self::Payload {
         &self.payload
     }
 

--- a/src/packet/pubcomp.rs
+++ b/src/packet/pubcomp.rs
@@ -33,7 +33,7 @@ impl PubcompPacket {
     }
 }
 
-impl<'a> Packet<'a> for PubcompPacket {
+impl Packet for PubcompPacket {
     type Payload = ();
 
     fn fixed_header(&self) -> &FixedHeader {
@@ -44,7 +44,7 @@ impl<'a> Packet<'a> for PubcompPacket {
         &self.payload
     }
 
-    fn encode_variable_headers<W: Write>(&self, writer: &mut W) -> Result<(), PacketError<'a, Self>> {
+    fn encode_variable_headers<W: Write>(&self, writer: &mut W) -> Result<(), PacketError<Self>> {
         self.packet_identifier.encode(writer)?;
 
         Ok(())
@@ -54,7 +54,7 @@ impl<'a> Packet<'a> for PubcompPacket {
         self.packet_identifier.encoded_length()
     }
 
-    fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<'a, Self>> {
+    fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {
         let packet_identifier: PacketIdentifier = PacketIdentifier::decode(reader)?;
         Ok(PubcompPacket {
                fixed_header: fixed_header,

--- a/src/packet/publish.rs
+++ b/src/packet/publish.rs
@@ -110,7 +110,7 @@ impl PublishPacket {
     }
 }
 
-impl<'a> Packet<'a> for PublishPacket {
+impl Packet for PublishPacket {
     type Payload = Vec<u8>;
 
     fn fixed_header(&self) -> &FixedHeader {
@@ -121,7 +121,7 @@ impl<'a> Packet<'a> for PublishPacket {
         &self.payload
     }
 
-    fn encode_variable_headers<W: Write>(&self, writer: &mut W) -> Result<(), PacketError<'a, Self>> {
+    fn encode_variable_headers<W: Write>(&self, writer: &mut W) -> Result<(), PacketError<Self>> {
         self.topic_name.encode(writer)?;
 
         if let Some(pkid) = self.packet_identifier.as_ref() {
@@ -139,7 +139,7 @@ impl<'a> Packet<'a> for PublishPacket {
                 .unwrap_or(0)
     }
 
-    fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<'a, Self>> {
+    fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {
         let topic_name: TopicName = TopicName::decode(reader)?;
 
         let packet_identifier = if fixed_header.packet_type.flags & 0x06 != 0 {

--- a/src/packet/publish.rs
+++ b/src/packet/publish.rs
@@ -57,7 +57,7 @@ impl PublishPacket {
 
     #[inline]
     fn calculate_remaining_length(&self) -> u32 {
-        self.encoded_variable_headers_length() + self.payload().encoded_length()
+        self.encoded_variable_headers_length() + self.payload_ref().encoded_length()
     }
 
     pub fn set_dup(&mut self, dup: bool) {
@@ -117,7 +117,11 @@ impl Packet for PublishPacket {
         &self.fixed_header
     }
 
-    fn payload(&self) -> &Self::Payload {
+    fn payload(self) -> Self::Payload {
+        self.payload
+    }
+
+    fn payload_ref(&self) -> &Self::Payload {
         &self.payload
     }
 

--- a/src/packet/pubrec.rs
+++ b/src/packet/pubrec.rs
@@ -33,7 +33,7 @@ impl PubrecPacket {
     }
 }
 
-impl<'a> Packet<'a> for PubrecPacket {
+impl Packet for PubrecPacket {
     type Payload = ();
 
     fn fixed_header(&self) -> &FixedHeader {
@@ -44,7 +44,7 @@ impl<'a> Packet<'a> for PubrecPacket {
         &self.payload
     }
 
-    fn encode_variable_headers<W: Write>(&self, writer: &mut W) -> Result<(), PacketError<'a, Self>> {
+    fn encode_variable_headers<W: Write>(&self, writer: &mut W) -> Result<(), PacketError<Self>> {
         self.packet_identifier.encode(writer)?;
 
         Ok(())
@@ -54,7 +54,7 @@ impl<'a> Packet<'a> for PubrecPacket {
         self.packet_identifier.encoded_length()
     }
 
-    fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<'a, Self>> {
+    fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {
         let packet_identifier: PacketIdentifier = PacketIdentifier::decode(reader)?;
         Ok(PubrecPacket {
                fixed_header: fixed_header,

--- a/src/packet/pubrec.rs
+++ b/src/packet/pubrec.rs
@@ -40,7 +40,11 @@ impl Packet for PubrecPacket {
         &self.fixed_header
     }
 
-    fn payload(&self) -> &Self::Payload {
+    fn payload(self) -> Self::Payload {
+        self.payload
+    }
+
+    fn payload_ref(&self) -> &Self::Payload {
         &self.payload
     }
 

--- a/src/packet/pubrel.rs
+++ b/src/packet/pubrel.rs
@@ -33,7 +33,7 @@ impl PubrelPacket {
     }
 }
 
-impl<'a> Packet<'a> for PubrelPacket {
+impl Packet for PubrelPacket {
     type Payload = ();
 
     fn fixed_header(&self) -> &FixedHeader {
@@ -44,7 +44,7 @@ impl<'a> Packet<'a> for PubrelPacket {
         &self.payload
     }
 
-    fn encode_variable_headers<W: Write>(&self, writer: &mut W) -> Result<(), PacketError<'a, Self>> {
+    fn encode_variable_headers<W: Write>(&self, writer: &mut W) -> Result<(), PacketError<Self>> {
         self.packet_identifier.encode(writer)?;
 
         Ok(())
@@ -54,7 +54,7 @@ impl<'a> Packet<'a> for PubrelPacket {
         self.packet_identifier.encoded_length()
     }
 
-    fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<'a, Self>> {
+    fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {
         let packet_identifier: PacketIdentifier = PacketIdentifier::decode(reader)?;
         Ok(PubrelPacket {
                fixed_header: fixed_header,

--- a/src/packet/pubrel.rs
+++ b/src/packet/pubrel.rs
@@ -40,7 +40,11 @@ impl Packet for PubrelPacket {
         &self.fixed_header
     }
 
-    fn payload(&self) -> &Self::Payload {
+    fn payload(self) -> Self::Payload {
+        self.payload
+    }
+
+    fn payload_ref(&self) -> &Self::Payload {
         &self.payload
     }
 

--- a/src/packet/suback.rs
+++ b/src/packet/suback.rs
@@ -79,7 +79,7 @@ impl SubackPacket {
     }
 }
 
-impl<'a> Packet<'a> for SubackPacket {
+impl Packet for SubackPacket {
     type Payload = SubackPacketPayload;
 
     fn fixed_header(&self) -> &FixedHeader {
@@ -90,7 +90,7 @@ impl<'a> Packet<'a> for SubackPacket {
         &self.payload
     }
 
-    fn encode_variable_headers<W: Write>(&self, writer: &mut W) -> Result<(), PacketError<'a, Self>> {
+    fn encode_variable_headers<W: Write>(&self, writer: &mut W) -> Result<(), PacketError<Self>> {
         self.packet_identifier.encode(writer)?;
 
         Ok(())
@@ -100,7 +100,7 @@ impl<'a> Packet<'a> for SubackPacket {
         self.packet_identifier.encoded_length()
     }
 
-    fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<'a, Self>> {
+    fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {
         let packet_identifier: PacketIdentifier = PacketIdentifier::decode(reader)?;
         let payload: SubackPacketPayload =
             SubackPacketPayload::decode_with(reader,
@@ -129,7 +129,7 @@ impl SubackPacketPayload {
     }
 }
 
-impl<'a> Encodable<'a> for SubackPacketPayload {
+impl Encodable for SubackPacketPayload {
     type Err = SubackPacketPayloadError;
 
     fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Self::Err> {
@@ -145,7 +145,7 @@ impl<'a> Encodable<'a> for SubackPacketPayload {
     }
 }
 
-impl<'a> Decodable<'a> for SubackPacketPayload {
+impl Decodable for SubackPacketPayload {
     type Err = SubackPacketPayloadError;
     type Cond = u32;
 

--- a/src/packet/suback.rs
+++ b/src/packet/suback.rs
@@ -86,7 +86,11 @@ impl Packet for SubackPacket {
         &self.fixed_header
     }
 
-    fn payload(&self) -> &Self::Payload {
+    fn payload(self) -> Self::Payload {
+        self.payload
+    }
+
+    fn payload_ref(&self) -> &Self::Payload {
         &self.payload
     }
 

--- a/src/packet/subscribe.rs
+++ b/src/packet/subscribe.rs
@@ -43,7 +43,7 @@ impl SubscribePacket {
     }
 }
 
-impl<'a> Packet<'a> for SubscribePacket {
+impl Packet for SubscribePacket {
     type Payload = SubscribePacketPayload;
 
     fn fixed_header(&self) -> &FixedHeader {
@@ -54,7 +54,7 @@ impl<'a> Packet<'a> for SubscribePacket {
         &self.payload
     }
 
-    fn encode_variable_headers<W: Write>(&self, writer: &mut W) -> Result<(), PacketError<'a, Self>> {
+    fn encode_variable_headers<W: Write>(&self, writer: &mut W) -> Result<(), PacketError<Self>> {
         self.packet_identifier.encode(writer)?;
 
         Ok(())
@@ -64,7 +64,7 @@ impl<'a> Packet<'a> for SubscribePacket {
         self.packet_identifier.encoded_length()
     }
 
-    fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<'a, Self>> {
+    fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {
         let packet_identifier: PacketIdentifier = PacketIdentifier::decode(reader)?;
         let payload: SubscribePacketPayload =
             SubscribePacketPayload::decode_with(reader,
@@ -95,7 +95,7 @@ impl SubscribePacketPayload {
     }
 }
 
-impl<'a> Encodable<'a> for SubscribePacketPayload {
+impl Encodable for SubscribePacketPayload {
     type Err = SubscribePacketPayloadError;
 
     fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Self::Err> {
@@ -114,7 +114,7 @@ impl<'a> Encodable<'a> for SubscribePacketPayload {
     }
 }
 
-impl<'a> Decodable<'a> for SubscribePacketPayload {
+impl Decodable for SubscribePacketPayload {
     type Err = SubscribePacketPayloadError;
     type Cond = u32;
 

--- a/src/packet/subscribe.rs
+++ b/src/packet/subscribe.rs
@@ -50,7 +50,11 @@ impl Packet for SubscribePacket {
         &self.fixed_header
     }
 
-    fn payload(&self) -> &Self::Payload {
+    fn payload(self) -> Self::Payload {
+        self.payload
+    }
+
+    fn payload_ref(&self) -> &Self::Payload {
         &self.payload
     }
 

--- a/src/packet/unsuback.rs
+++ b/src/packet/unsuback.rs
@@ -33,7 +33,7 @@ impl UnsubackPacket {
     }
 }
 
-impl<'a> Packet<'a> for UnsubackPacket {
+impl Packet for UnsubackPacket {
     type Payload = ();
 
     fn fixed_header(&self) -> &FixedHeader {
@@ -44,7 +44,7 @@ impl<'a> Packet<'a> for UnsubackPacket {
         &self.payload
     }
 
-    fn encode_variable_headers<W: Write>(&self, writer: &mut W) -> Result<(), PacketError<'a, Self>> {
+    fn encode_variable_headers<W: Write>(&self, writer: &mut W) -> Result<(), PacketError<Self>> {
         self.packet_identifier.encode(writer)?;
 
         Ok(())
@@ -54,7 +54,7 @@ impl<'a> Packet<'a> for UnsubackPacket {
         self.packet_identifier.encoded_length()
     }
 
-    fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<'a, Self>> {
+    fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {
         let packet_identifier: PacketIdentifier = PacketIdentifier::decode(reader)?;
         Ok(UnsubackPacket {
                fixed_header: fixed_header,

--- a/src/packet/unsuback.rs
+++ b/src/packet/unsuback.rs
@@ -40,7 +40,11 @@ impl Packet for UnsubackPacket {
         &self.fixed_header
     }
 
-    fn payload(&self) -> &Self::Payload {
+    fn payload(self) -> Self::Payload {
+        self.payload
+    }
+
+    fn payload_ref(&self) -> &Self::Payload {
         &self.payload
     }
 

--- a/src/packet/unsubscribe.rs
+++ b/src/packet/unsubscribe.rs
@@ -41,7 +41,7 @@ impl UnsubscribePacket {
     }
 }
 
-impl<'a> Packet<'a> for UnsubscribePacket {
+impl Packet for UnsubscribePacket {
     type Payload = UnsubscribePacketPayload;
 
     fn fixed_header(&self) -> &FixedHeader {
@@ -52,7 +52,7 @@ impl<'a> Packet<'a> for UnsubscribePacket {
         &self.payload
     }
 
-    fn encode_variable_headers<W: Write>(&self, writer: &mut W) -> Result<(), PacketError<'a, Self>> {
+    fn encode_variable_headers<W: Write>(&self, writer: &mut W) -> Result<(), PacketError<Self>> {
         self.packet_identifier.encode(writer)?;
 
         Ok(())
@@ -62,7 +62,7 @@ impl<'a> Packet<'a> for UnsubscribePacket {
         self.packet_identifier.encoded_length()
     }
 
-    fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<'a, Self>> {
+    fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {
         let packet_identifier: PacketIdentifier = PacketIdentifier::decode(reader)?;
         let payload: UnsubscribePacketPayload =
             UnsubscribePacketPayload::decode_with(reader,
@@ -92,7 +92,7 @@ impl UnsubscribePacketPayload {
     }
 }
 
-impl<'a> Encodable<'a> for UnsubscribePacketPayload {
+impl Encodable for UnsubscribePacketPayload {
     type Err = UnsubscribePacketPayloadError;
 
     fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Self::Err> {
@@ -110,7 +110,7 @@ impl<'a> Encodable<'a> for UnsubscribePacketPayload {
     }
 }
 
-impl<'a> Decodable<'a> for UnsubscribePacketPayload {
+impl Decodable for UnsubscribePacketPayload {
     type Err = UnsubscribePacketPayloadError;
     type Cond = u32;
 

--- a/src/packet/unsubscribe.rs
+++ b/src/packet/unsubscribe.rs
@@ -48,7 +48,11 @@ impl Packet for UnsubscribePacket {
         &self.fixed_header
     }
 
-    fn payload(&self) -> &Self::Payload {
+    fn payload(self) -> Self::Payload {
+        self.payload
+    }
+
+    fn payload_ref(&self) -> &Self::Payload {
         &self.payload
     }
 

--- a/src/topic_filter.rs
+++ b/src/topic_filter.rs
@@ -56,7 +56,7 @@ impl TopicFilter {
     }
 }
 
-impl<'a> Encodable<'a> for TopicFilter {
+impl Encodable for TopicFilter {
     type Err = TopicFilterError;
 
     fn encode<W: Write>(&self, writer: &mut W) -> Result<(), TopicFilterError> {
@@ -70,7 +70,7 @@ impl<'a> Encodable<'a> for TopicFilter {
     }
 }
 
-impl<'a> Decodable<'a> for TopicFilter {
+impl Decodable for TopicFilter {
     type Err = TopicFilterError;
     type Cond = ();
 

--- a/src/topic_name.rs
+++ b/src/topic_name.rs
@@ -61,7 +61,7 @@ impl Deref for TopicName {
     }
 }
 
-impl<'a> Encodable<'a> for TopicName {
+impl Encodable for TopicName {
     type Err = TopicNameError;
 
     fn encode<W: Write>(&self, writer: &mut W) -> Result<(), TopicNameError> {
@@ -75,7 +75,7 @@ impl<'a> Encodable<'a> for TopicName {
     }
 }
 
-impl<'a> Decodable<'a> for TopicName {
+impl Decodable for TopicName {
     type Err = TopicNameError;
     type Cond = ();
 


### PR DESCRIPTION
Most of this PR was centered around adding the tokio support, but I tried to simplify things here and there (eg lifetimes) so that the tokio support would be easier to implement.

The asynchronous parse functions are pretty much a direct translation of the synchronous parsing functions, and I ported the sub-client to be asynchronous and tested that it still all works.

I haven't yet written an explicit send function, because all it would do is write to a buffer and then call tokio_io::write_all, and that didn't seem worthy of extending the API.