### PR TITLE
Add peek/peek_finalize to VariablePacket

### DIFF
--- a/src/control/fixed_header.rs
+++ b/src/control/fixed_header.rs
@@ -47,18 +47,17 @@ impl FixedHeader {
 
     /// Asynchronously parse a single fixed header from an AsyncRead type, such as a network
     /// socket.
-    pub fn parse<A: AsyncRead>(rdr: A) -> impl Future<Item = (A, Self, [u8; 2]), Error = FixedHeaderError> {
+    pub fn parse<A: AsyncRead>(rdr: A) -> impl Future<Item = (A, Self, Vec<u8>), Error = FixedHeaderError> {
         async_io::read_exact(rdr, [0u8])
             .from_err()
             .and_then(|(rdr, [type_val])| {
-                let mut data: [u8; 2] = [type_val, 0xff];
-                future::loop_fn((rdr, 0, 0), move |(rdr, mut cur, i)| {
+                let mut data: Vec<u8> = Vec::new();
+                data.push(type_val);
+                future::loop_fn((rdr, 0, 0, data), move |(rdr, mut cur, i, mut data)| {
                     async_io::read_exact(rdr, [0u8])
                         .from_err()
                         .and_then(move |(rdr, [byte])| {
-                            if i == 0 {
-                                data[1] = byte;
-                            }
+                            data.push(byte);
 
                             cur |= (u32::from(byte) & 0x7F) << (7 * i);
 
@@ -69,7 +68,7 @@ impl FixedHeader {
                             if byte & 0x80 == 0 {
                                 Ok(future::Loop::Break((rdr, cur, data)))
                             } else {
-                                Ok(future::Loop::Continue((rdr, cur, i + 1)))
+                                Ok(future::Loop::Continue((rdr, cur, i + 1, data)))
                             }
                         })
                 }).and_then(move |(rdr, remaining_len, data)| match PacketType::from_u8(type_val) {

--- a/src/control/fixed_header.rs
+++ b/src/control/fixed_header.rs
@@ -47,14 +47,19 @@ impl FixedHeader {
 
     /// Asynchronously parse a single fixed header from an AsyncRead type, such as a network
     /// socket.
-    pub fn parse<A: AsyncRead>(rdr: A) -> impl Future<Item = (A, Self), Error = FixedHeaderError> {
+    pub fn parse<A: AsyncRead>(rdr: A) -> impl Future<Item = (A, Self, [u8; 2]), Error = FixedHeaderError> {
         async_io::read_exact(rdr, [0u8])
             .from_err()
             .and_then(|(rdr, [type_val])| {
-                future::loop_fn((rdr, 0, 0), |(rdr, mut cur, i)| {
+                let mut data: [u8; 2] = [type_val, 0xff];
+                future::loop_fn((rdr, 0, 0), move |(rdr, mut cur, i)| {
                     async_io::read_exact(rdr, [0u8])
                         .from_err()
                         .and_then(move |(rdr, [byte])| {
+                            if i == 0 {
+                                data[1] = byte;
+                            }
+
                             cur |= (u32::from(byte) & 0x7F) << (7 * i);
 
                             if i >= 4 {
@@ -62,13 +67,13 @@ impl FixedHeader {
                             }
 
                             if byte & 0x80 == 0 {
-                                Ok(future::Loop::Break((rdr, cur)))
+                                Ok(future::Loop::Break((rdr, cur, data)))
                             } else {
                                 Ok(future::Loop::Continue((rdr, cur, i + 1)))
                             }
                         })
-                }).and_then(move |(rdr, remaining_len)| match PacketType::from_u8(type_val) {
-                    Ok(packet_type) => Ok((rdr, FixedHeader::new(packet_type, remaining_len))),
+                }).and_then(move |(rdr, remaining_len, data)| match PacketType::from_u8(type_val) {
+                    Ok(packet_type) => Ok((rdr, FixedHeader::new(packet_type, remaining_len), data)),
                     Err(PacketTypeError::UndefinedType(ty, _)) => {
                         Err(FixedHeaderError::Unrecognized(ty, remaining_len))
                     }

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -192,7 +192,7 @@ macro_rules! impl_variable_packet {
         }
 
         impl VariablePacket {
-            pub fn peek<A: AsyncRead>(rdr: A) -> impl Future<Item = (A, FixedHeader, [u8; 2]), Error = VariablePacketError> {
+            pub fn peek<A: AsyncRead>(rdr: A) -> impl Future<Item = (A, FixedHeader, Vec<u8>), Error = VariablePacketError> {
                 FixedHeader::parse(rdr).then(|result| {
                     let (rdr, fixed_header, data) = match result {
                         Ok((rdr, header, data)) => (rdr, header, data),
@@ -228,7 +228,7 @@ macro_rules! impl_variable_packet {
                                 )+
                             };
                             let mut result = Vec::new();
-                            result.extend(header_buffer.iter());
+                            result.extend(header_buffer);
                             result.extend(packet);
                             Ok((result, output))
                         })

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -192,10 +192,10 @@ macro_rules! impl_variable_packet {
         }
 
         impl VariablePacket {
-            pub fn parse<A: AsyncRead>(rdr: A) -> impl Future<Item = (A, Self), Error = VariablePacketError> {
+            pub fn peek<A: AsyncRead>(rdr: A) -> impl Future<Item = (A, FixedHeader, [u8; 2]), Error = VariablePacketError> {
                 FixedHeader::parse(rdr).then(|result| {
-                    let (rdr, fixed_header) = match result {
-                        Ok((rdr, header)) => (rdr, header),
+                    let (rdr, fixed_header, data) = match result {
+                        Ok((rdr, header, data)) => (rdr, header, data),
                         Err(FixedHeaderError::Unrecognized(code, _length)) => {
                             // can't read excess bytes from rdr as it was dropped when an error
                             // occurred
@@ -209,8 +209,33 @@ macro_rules! impl_variable_packet {
                         Err(err) => return Err(From::from(err))
                     };
 
-                    Ok((rdr, fixed_header))
-                }).and_then(|(rdr, fixed_header)| {
+                    Ok((rdr, fixed_header, data))
+                })
+            }
+            pub fn peek_finalize<A: AsyncRead>(rdr: A) -> impl Future<Item = (Vec<u8>, Self), Error = VariablePacketError> {
+                Self::peek(rdr).and_then(|(rdr, fixed_header, header_buffer)| {
+                    let packet = vec![0u8; fixed_header.remaining_length as usize];
+                    async_io::read_exact(rdr, packet)
+                        .from_err()
+                        .and_then(move |(_rdr, packet)| {
+                            let mut buff_rdr = Cursor::new(packet.clone());
+                            let output = match fixed_header.packet_type.control_type {
+                                $(
+                                    ControlType::$hdr => {
+                                        let pk = <$name as Packet>::decode_packet(&mut buff_rdr, fixed_header)?;
+                                        VariablePacket::$name(pk)
+                                    }
+                                )+
+                            };
+                            let mut result = Vec::new();
+                            result.extend(header_buffer.iter());
+                            result.extend(packet);
+                            Ok((result, output))
+                        })
+                })
+            }
+            pub fn parse<A: AsyncRead>(rdr: A) -> impl Future<Item = (A, Self), Error = VariablePacketError> {
+                Self::peek(rdr).and_then(|(rdr, fixed_header, _)| {
                     let buffer = vec![0u8; fixed_header.remaining_length as usize];
                     async_io::read_exact(rdr, buffer)
                         .from_err()
@@ -431,4 +456,54 @@ mod test {
 
         assert_eq!(var_packet, decoded_packet);
     }
+
+    #[test]
+    fn test_variable_packet_async_parse() {
+        use std::io::Cursor;
+        let packet = ConnectPacket::new("MQTT".to_owned(), "1234".to_owned());
+
+        // Wrap it
+        let var_packet = VariablePacket::new(packet);
+
+        // Encode
+        let mut buf = Vec::new();
+        var_packet.encode(&mut buf).unwrap();
+
+        // Parse
+        let async_buf = Cursor::new(buf);
+        match VariablePacket::parse(async_buf).wait() {
+            Err(_) => assert!(false),
+            Ok((_, decoded_packet)) => assert_eq!(var_packet, decoded_packet),
+        }
+    }
+
+    #[test]
+    fn test_variable_packet_async_peek() {
+        use std::io::Cursor;
+        let packet = ConnectPacket::new("MQTT".to_owned(), "1234".to_owned());
+
+        // Wrap it
+        let var_packet = VariablePacket::new(packet);
+
+        // Encode
+        let mut buf = Vec::new();
+        var_packet.encode(&mut buf).unwrap();
+
+        // Peek
+        let async_buf = Cursor::new(buf.clone());
+        match VariablePacket::peek(async_buf.clone()).wait() {
+            Err(_) => assert!(false),
+            Ok((_, fixed_header, _)) => assert_eq!(fixed_header.packet_type.control_type, ControlType::Connect),
+        }
+
+        // Read the rest
+        match VariablePacket::peek_finalize(async_buf).wait() {
+            Err(_) => assert!(false),
+            Ok((peeked_buffer, peeked_packet)) => {
+                assert_eq!(peeked_buffer, buf);
+                assert_eq!(peeked_packet, var_packet);
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
VariablePacket::peek was refactored from parse to read the protocol header and additionally return the header bytes ( ignored in parse but used in peek_finalize ). 
VariablePacket::peek_finialize reads the rest of the packet returning a decoded packet and the entire buffer. 
VariablePacket::parse uses peek to read the header, no braking changes for anything existing. 

The use case for this is that as a broker/bridge you want to be able to early reject connections by peeking into the fixed header if the control type is relevant to the current situation, logging/aborting/exiting without processing the remaining data. To avoid unnecessary encoding/decoding or rereading the buffer in order to forward the packet, the entire packet buffer is returned in peek_finalize.

Added basic tests for VariablePacket::parse and VariablePacket::peek(_finalize)

This affects only tokio async use.



