### PR TITLE
Add impl for fn source(&self) to errors

### DIFF
--- a/src/control/fixed_header.rs
+++ b/src/control/fixed_header.rs
@@ -199,7 +199,7 @@ impl Error for FixedHeaderError {
         }
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             &FixedHeaderError::MalformedRemainingLength => None,
             &FixedHeaderError::Unrecognized(..) => None,

--- a/src/control/variable_header/mod.rs
+++ b/src/control/variable_header/mod.rs
@@ -84,7 +84,7 @@ impl Error for VariableHeaderError {
         }
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             &VariableHeaderError::IoError(ref err) => Some(err),
             &VariableHeaderError::StringEncodeError(ref err) => Some(err),

--- a/src/encodable.rs
+++ b/src/encodable.rs
@@ -222,7 +222,7 @@ impl Error for StringEncodeError {
         }
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             &StringEncodeError::IoError(ref err) => Some(err),
             &StringEncodeError::FromUtf8Error(ref err) => Some(err),

--- a/src/packet/connect.rs
+++ b/src/packet/connect.rs
@@ -340,7 +340,7 @@ impl Error for ConnectPacketPayloadError {
         }
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             &ConnectPacketPayloadError::IoError(ref err) => Some(err),
             &ConnectPacketPayloadError::StringEncodeError(ref err) => Some(err),

--- a/src/packet/suback.rs
+++ b/src/packet/suback.rs
@@ -200,7 +200,7 @@ impl Error for SubackPacketPayloadError {
         }
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             &SubackPacketPayloadError::IoError(ref err) => Some(err),
             &SubackPacketPayloadError::InvalidSubscribeReturnCode(..) => None,

--- a/src/packet/subscribe.rs
+++ b/src/packet/subscribe.rs
@@ -177,7 +177,7 @@ impl Error for SubscribePacketPayloadError {
         }
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             &SubscribePacketPayloadError::IoError(ref err) => Some(err),
             &SubscribePacketPayloadError::FromUtf8Error(ref err) => Some(err),

--- a/src/packet/unsubscribe.rs
+++ b/src/packet/unsubscribe.rs
@@ -163,7 +163,7 @@ impl Error for UnsubscribePacketPayloadError {
         }
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             &UnsubscribePacketPayloadError::IoError(ref err) => Some(err),
             &UnsubscribePacketPayloadError::FromUtf8Error(ref err) => Some(err),

--- a/src/topic_filter.rs
+++ b/src/topic_filter.rs
@@ -148,7 +148,7 @@ impl Error for TopicFilterError {
         }
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             &TopicFilterError::StringEncodeError(ref err) => Some(err),
             &TopicFilterError::InvalidTopicFilter(..) => None,

--- a/src/topic_name.rs
+++ b/src/topic_name.rs
@@ -110,7 +110,7 @@ impl Error for TopicNameError {
         }
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             &TopicNameError::StringEncodeError(ref err) => Some(err),
             &TopicNameError::InvalidTopicName(..) => None,


### PR DESCRIPTION
`std::error::Error::cause` was deprecated in Rust 1.33.0, and without an impl for `source` things like `find_root_cause` in the failure crate don't work correctly.

This patch moves the current implementations for `cause` into `source`. The default `cause` impl from rustc 1.30 calls `source`, so this shouldn't break backwards compatibility.