### PR TITLE
[BETA] Prepare for rustc 1.39, futures 0.3, tokio 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Y. T. Chung <zonyitoo@gmail.com>"]
 name = "mqtt-protocol"
-version = "0.8.0-alpha.2"
+version = "0.8.0-alpha.3"
 edition = "2018"
 license = "MIT/Apache-2.0"
 description = "MQTT Protocol Library"
@@ -14,8 +14,8 @@ byteorder = "1.3"
 log = "0.4"
 regex = "1.3"
 lazy_static = "1.4"
-tokio = "0.2.0-alpha.6"
-futures-preview = "0.3.0-alpha.19"
+tokio = "0.2"
+futures = "0.3"
 
 [dev-dependencies]
 clap = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ repository = "https://github.com/zonyitoo/mqtt-rs"
 documentation = "https://docs.rs/mqtt-protocol"
 
 [dependencies]
-byteorder = "1.2"
+byteorder = "1.3"
 log = "0.4"
-regex = "1.0"
-lazy_static = "1.1"
+regex = "1.3"
+lazy_static = "1.4"
 tokio = "0.2.0-alpha.6"
 futures-preview = "0.3.0-alpha.19"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Y. T. Chung <zonyitoo@gmail.com>"]
 name = "mqtt-protocol"
-version = "0.7.0"
+version = "0.8.0-alpha.1"
 edition = "2018"
 license = "MIT/Apache-2.0"
 description = "MQTT Protocol Library"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,15 +14,14 @@ byteorder = "1.2"
 log = "0.4"
 regex = "1.0"
 lazy_static = "1.1"
-tokio-io = "0.1"
-futures = "0.1"
+tokio = "0.2.0-alpha.6"
+futures-preview = "0.3.0-alpha.19"
 
 [dev-dependencies]
 clap = "2"
 env_logger = "0.5"
 uuid = { version = "0.7", features = ["v4"] }
 time = "0.1"
-tokio = "0.1"
 
 [lib]
 name = "mqtt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["Y. T. Chung <zonyitoo@gmail.com>"]
 name = "mqtt-protocol"
 version = "0.7.0"
+edition = "2018"
 license = "MIT/Apache-2.0"
 description = "MQTT Protocol Library"
 keywords = ["mqtt", "protocol"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Y. T. Chung <zonyitoo@gmail.com>"]
 name = "mqtt-protocol"
-version = "0.8.0-alpha.1"
+version = "0.8.0-alpha.2"
 edition = "2018"
 license = "MIT/Apache-2.0"
 description = "MQTT Protocol Library"
@@ -22,6 +22,7 @@ clap = "2"
 env_logger = "0.5"
 uuid = { version = "0.7", features = ["v4"] }
 time = "0.1"
+pin-project = "*"
 
 [lib]
 name = "mqtt"

--- a/examples/pub-client.rs
+++ b/examples/pub-client.rs
@@ -147,11 +147,11 @@ fn main() {
         let mut line = String::new();
         stdin.read_line(&mut line).unwrap();
 
-        if line.trim_right() == "" {
+        if line.trim_end() == "" {
             continue;
         }
 
-        let message = format!("{}: {}", user_name, line.trim_right());
+        let message = format!("{}: {}", user_name, line.trim_end());
 
         for chan in &channels {
             let publish_packet = PublishPacket::new(chan.clone(), QoSWithPacketIdentifier::Level0, message.clone());

--- a/src/control/fixed_header.rs
+++ b/src/control/fixed_header.rs
@@ -10,8 +10,8 @@ use byteorder::{ReadBytesExt, WriteBytesExt};
 use futures::{future, Future};
 use tokio_io::{io as async_io, AsyncRead};
 
-use {Decodable, Encodable};
-use control::packet_type::{PacketType, PacketTypeError};
+use crate::{Decodable, Encodable};
+use crate::control::packet_type::{PacketType, PacketTypeError};
 
 /// Fixed header for each MQTT control packet
 ///
@@ -214,8 +214,8 @@ impl Error for FixedHeaderError {
 mod test {
     use super::*;
 
-    use {Decodable, Encodable};
-    use control::packet_type::{ControlType, PacketType};
+    use crate::{Decodable, Encodable};
+    use crate::control::packet_type::{ControlType, PacketType};
     use std::io::Cursor;
 
     #[test]

--- a/src/control/variable_header/connect_ack_flags.rs
+++ b/src/control/variable_header/connect_ack_flags.rs
@@ -3,8 +3,8 @@ use std::io::{Read, Write};
 
 use byteorder::{ReadBytesExt, WriteBytesExt};
 
-use {Decodable, Encodable};
-use control::variable_header::VariableHeaderError;
+use crate::{Decodable, Encodable};
+use crate::control::variable_header::VariableHeaderError;
 
 /// Flags in `CONNACK` packet
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]

--- a/src/control/variable_header/connect_flags.rs
+++ b/src/control/variable_header/connect_flags.rs
@@ -3,8 +3,8 @@ use std::io::{Read, Write};
 
 use byteorder::{ReadBytesExt, WriteBytesExt};
 
-use {Decodable, Encodable};
-use control::variable_header::VariableHeaderError;
+use crate::{Decodable, Encodable};
+use crate::control::variable_header::VariableHeaderError;
 
 /// Flags for `CONNECT` packet
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]

--- a/src/control/variable_header/connect_ret_code.rs
+++ b/src/control/variable_header/connect_ret_code.rs
@@ -3,8 +3,8 @@ use std::io::{Read, Write};
 
 use byteorder::{ReadBytesExt, WriteBytesExt};
 
-use {Decodable, Encodable};
-use control::variable_header::VariableHeaderError;
+use crate::{Decodable, Encodable};
+use crate::control::variable_header::VariableHeaderError;
 
 pub const CONNECTION_ACCEPTED: u8 = 0x00;
 pub const UNACCEPTABLE_PROTOCOL_VERSION: u8 = 0x01;

--- a/src/control/variable_header/keep_alive.rs
+++ b/src/control/variable_header/keep_alive.rs
@@ -3,8 +3,8 @@ use std::io::{Read, Write};
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
-use {Decodable, Encodable};
-use control::variable_header::VariableHeaderError;
+use crate::{Decodable, Encodable};
+use crate::control::variable_header::VariableHeaderError;
 
 /// Keep alive time interval
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]

--- a/src/control/variable_header/mod.rs
+++ b/src/control/variable_header/mod.rs
@@ -6,8 +6,8 @@ use std::fmt;
 use std::io;
 use std::string::FromUtf8Error;
 
-use encodable::StringEncodeError;
-use topic_name::TopicNameError;
+use crate::encodable::StringEncodeError;
+use crate::topic_name::TopicNameError;
 
 pub use self::connect_ack_flags::ConnackFlags;
 pub use self::connect_flags::ConnectFlags;

--- a/src/control/variable_header/packet_identifier.rs
+++ b/src/control/variable_header/packet_identifier.rs
@@ -3,8 +3,8 @@ use std::io::{Read, Write};
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
-use {Decodable, Encodable};
-use control::variable_header::VariableHeaderError;
+use crate::{Decodable, Encodable};
+use crate::control::variable_header::VariableHeaderError;
 
 /// Packet identifier
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]

--- a/src/control/variable_header/protocol_level.rs
+++ b/src/control/variable_header/protocol_level.rs
@@ -5,8 +5,8 @@ use std::io::{Read, Write};
 
 use byteorder::{ReadBytesExt, WriteBytesExt};
 
-use {Decodable, Encodable};
-use control::variable_header::VariableHeaderError;
+use crate::{Decodable, Encodable};
+use crate::control::variable_header::VariableHeaderError;
 
 pub const SPEC_3_1_1: u8 = 0x04;
 

--- a/src/control/variable_header/protocol_name.rs
+++ b/src/control/variable_header/protocol_name.rs
@@ -1,8 +1,8 @@
 use std::convert::From;
 use std::io::{Read, Write};
 
-use {Decodable, Encodable};
-use control::variable_header::VariableHeaderError;
+use crate::{Decodable, Encodable};
+use crate::control::variable_header::VariableHeaderError;
 
 /// Protocol name in variable header
 ///

--- a/src/control/variable_header/topic_name.rs
+++ b/src/control/variable_header/topic_name.rs
@@ -1,9 +1,9 @@
 use std::convert::{From, Into};
 use std::io::{Read, Write};
 
-use {Decodable, Encodable};
-use control::variable_header::VariableHeaderError;
-use topic_name::TopicName;
+use crate::{Decodable, Encodable};
+use crate::control::variable_header::VariableHeaderError;
+use crate::topic_name::TopicName;
 
 /// Topic name wrapper
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,13 +34,8 @@
 //! assert_eq!(VariablePacket::PublishPacket(packet), auto_decode);
 //! ```
 
-extern crate log;
-extern crate byteorder;
-extern crate regex;
 #[macro_use]
 extern crate lazy_static;
-extern crate futures;
-extern crate tokio_io;
 
 pub use self::encodable::{Decodable, Encodable};
 pub use self::qos::QualityOfService;

--- a/src/packet/connack.rs
+++ b/src/packet/connack.rs
@@ -2,10 +2,10 @@
 
 use std::io::{Read, Write};
 
-use {Decodable, Encodable};
-use control::{ControlType, FixedHeader, PacketType};
-use control::variable_header::{ConnackFlags, ConnectReturnCode};
-use packet::{Packet, PacketError};
+use crate::{Decodable, Encodable};
+use crate::control::{ControlType, FixedHeader, PacketType};
+use crate::control::variable_header::{ConnackFlags, ConnectReturnCode};
+use crate::packet::{Packet, PacketError};
 
 /// `CONNACK` packet
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -79,8 +79,8 @@ mod test {
 
     use std::io::Cursor;
 
-    use {Decodable, Encodable};
-    use control::variable_header::ConnectReturnCode;
+    use crate::{Decodable, Encodable};
+    use crate::control::variable_header::ConnectReturnCode;
 
     #[test]
     pub fn test_connack_packet_basic() {

--- a/src/packet/connect.rs
+++ b/src/packet/connect.rs
@@ -4,13 +4,13 @@ use std::error::Error;
 use std::fmt;
 use std::io::{self, Read, Write};
 
-use {Decodable, Encodable};
-use control::{ControlType, FixedHeader, PacketType};
-use control::variable_header::{ConnectFlags, KeepAlive, ProtocolLevel, ProtocolName};
-use control::variable_header::protocol_level::SPEC_3_1_1;
-use encodable::{StringEncodeError, VarBytes};
-use packet::{Packet, PacketError};
-use topic_name::{TopicName, TopicNameError};
+use crate::{Decodable, Encodable};
+use crate::control::{ControlType, FixedHeader, PacketType};
+use crate::control::variable_header::{ConnectFlags, KeepAlive, ProtocolLevel, ProtocolName};
+use crate::control::variable_header::protocol_level::SPEC_3_1_1;
+use crate::encodable::{StringEncodeError, VarBytes};
+use crate::packet::{Packet, PacketError};
+use crate::topic_name::{TopicName, TopicNameError};
 
 /// `CONNECT` packet
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -373,7 +373,7 @@ mod test {
 
     use std::io::Cursor;
 
-    use {Decodable, Encodable};
+    use crate::{Decodable, Encodable};
 
     #[test]
     fn test_connect_packet_encode_basic() {

--- a/src/packet/disconnect.rs
+++ b/src/packet/disconnect.rs
@@ -2,8 +2,8 @@
 
 use std::io::{Read, Write};
 
-use control::{ControlType, FixedHeader, PacketType};
-use packet::{Packet, PacketError};
+use crate::control::{ControlType, FixedHeader, PacketType};
+use crate::packet::{Packet, PacketError};
 
 /// `DISCONNECT` packet
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -453,8 +453,12 @@ mod test {
         assert_eq!(var_packet, decoded_packet);
     }
 
+    use tokio::runtime::current_thread::Runtime;
     #[test]
     fn test_variable_packet_async_parse() {
+        Runtime::new().unwrap().block_on(async_test_variable_packet_async_parse());
+    }
+    async fn async_test_variable_packet_async_parse() {
         use std::io::Cursor;
         let packet = ConnectPacket::new("MQTT".to_owned(), "1234".to_owned());
 
@@ -467,7 +471,7 @@ mod test {
 
         // Parse
         let async_buf = Cursor::new(buf);
-        match VariablePacket::parse(async_buf).wait() {
+        match VariablePacket::parse(async_buf).await {
             Err(_) => assert!(false),
             Ok((_, decoded_packet)) => assert_eq!(var_packet, decoded_packet),
         }
@@ -475,6 +479,9 @@ mod test {
 
     #[test]
     fn test_variable_packet_async_peek() {
+        Runtime::new().unwrap().block_on(async_test_variable_packet_async_peek());
+    }
+    async fn async_test_variable_packet_async_peek() {
         use std::io::Cursor;
         let packet = ConnectPacket::new("MQTT".to_owned(), "1234".to_owned());
 
@@ -487,13 +494,13 @@ mod test {
 
         // Peek
         let async_buf = Cursor::new(buf.clone());
-        match VariablePacket::peek(async_buf.clone()).wait() {
+        match VariablePacket::peek(async_buf.clone()).await {
             Err(_) => assert!(false),
             Ok((_, fixed_header, _)) => assert_eq!(fixed_header.packet_type.control_type, ControlType::Connect),
         }
 
         // Read the rest
-        match VariablePacket::peek_finalize(async_buf).wait() {
+        match VariablePacket::peek_finalize(async_buf).await {
             Err(_) => assert!(false),
             Ok((_, peeked_buffer, peeked_packet)) => {
                 assert_eq!(peeked_buffer, buf);

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -459,7 +459,6 @@ mod test {
         Runtime::new().unwrap().block_on(async_test_variable_packet_async_parse());
     }
     async fn async_test_variable_packet_async_parse() {
-        use std::io::Cursor;
         let packet = ConnectPacket::new("MQTT".to_owned(), "1234".to_owned());
 
         // Wrap it
@@ -482,7 +481,6 @@ mod test {
         Runtime::new().unwrap().block_on(async_test_variable_packet_async_peek());
     }
     async fn async_test_variable_packet_async_peek() {
-        use std::io::Cursor;
         let packet = ConnectPacket::new("MQTT".to_owned(), "1234".to_owned());
 
         // Wrap it

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -8,13 +8,13 @@ use std::io::{self, Read, Write, Cursor};
 use futures::Future;
 use tokio_io::{io as async_io, AsyncRead};
 
-use {Decodable, Encodable};
-use control::ControlType;
-use control::FixedHeader;
-use control::fixed_header::FixedHeaderError;
-use control::variable_header::VariableHeaderError;
-use encodable::StringEncodeError;
-use topic_name::TopicNameError;
+use crate::{Decodable, Encodable};
+use crate::control::ControlType;
+use crate::control::FixedHeader;
+use crate::control::fixed_header::FixedHeaderError;
+use crate::control::variable_header::VariableHeaderError;
+use crate::encodable::StringEncodeError;
+use crate::topic_name::TopicNameError;
 
 pub use self::connack::ConnackPacket;
 pub use self::connect::ConnectPacket;
@@ -298,13 +298,13 @@ macro_rules! impl_variable_packet {
                             Err(FixedHeaderError::Unrecognized(code, length)) => {
                                 let reader = &mut reader.take(length as u64);
                                 let mut buf = Vec::with_capacity(length as usize);
-                                try!(reader.read_to_end(&mut buf));
+                                reader.read_to_end(&mut buf)?;
                                 return Err(VariablePacketError::UnrecognizedPacket(code, buf));
                             },
                             Err(FixedHeaderError::ReservedType(code, length)) => {
                                 let reader = &mut reader.take(length as u64);
                                 let mut buf = Vec::with_capacity(length as usize);
-                                try!(reader.read_to_end(&mut buf));
+                                reader.read_to_end(&mut buf)?;
                                 return Err(VariablePacketError::ReservedPacket(code, buf));
                             },
                             Err(err) => return Err(From::from(err))
@@ -316,7 +316,7 @@ macro_rules! impl_variable_packet {
                 match fixed_header.packet_type.control_type {
                     $(
                         ControlType::$hdr => {
-                            let pk = try!(<$name as Packet>::decode_packet(reader, fixed_header));
+                            let pk = <$name as Packet>::decode_packet(reader, fixed_header)?;
                             Ok(VariablePacket::$name(pk))
                         }
                     )+
@@ -437,7 +437,7 @@ mod test {
 
     use std::io::Cursor;
 
-    use {Decodable, Encodable};
+    use crate::{Decodable, Encodable};
 
     #[test]
     fn test_variable_packet_basic() {

--- a/src/packet/pingreq.rs
+++ b/src/packet/pingreq.rs
@@ -2,8 +2,8 @@
 
 use std::io::{Read, Write};
 
-use control::{ControlType, FixedHeader, PacketType};
-use packet::{Packet, PacketError};
+use crate::control::{ControlType, FixedHeader, PacketType};
+use crate::packet::{Packet, PacketError};
 
 /// `PINGREQ` packet
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/src/packet/pingresp.rs
+++ b/src/packet/pingresp.rs
@@ -2,8 +2,8 @@
 
 use std::io::{Read, Write};
 
-use control::{ControlType, FixedHeader, PacketType};
-use packet::{Packet, PacketError};
+use crate::control::{ControlType, FixedHeader, PacketType};
+use crate::packet::{Packet, PacketError};
 
 /// `PINGRESP` packet
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/src/packet/puback.rs
+++ b/src/packet/puback.rs
@@ -2,10 +2,10 @@
 
 use std::io::{Read, Write};
 
-use {Decodable, Encodable};
-use control::{ControlType, FixedHeader, PacketType};
-use control::variable_header::PacketIdentifier;
-use packet::{Packet, PacketError};
+use crate::{Decodable, Encodable};
+use crate::control::{ControlType, FixedHeader, PacketType};
+use crate::control::variable_header::PacketIdentifier;
+use crate::packet::{Packet, PacketError};
 
 /// `PUBACK` packet
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/src/packet/pubcomp.rs
+++ b/src/packet/pubcomp.rs
@@ -2,10 +2,10 @@
 
 use std::io::{Read, Write};
 
-use {Decodable, Encodable};
-use control::{ControlType, FixedHeader, PacketType};
-use control::variable_header::PacketIdentifier;
-use packet::{Packet, PacketError};
+use crate::{Decodable, Encodable};
+use crate::control::{ControlType, FixedHeader, PacketType};
+use crate::control::variable_header::PacketIdentifier;
+use crate::packet::{Packet, PacketError};
 
 /// `PUBCOMP` packet
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/src/packet/publish.rs
+++ b/src/packet/publish.rs
@@ -2,12 +2,12 @@
 
 use std::io::{Read, Write};
 
-use {Decodable, Encodable};
-use control::{ControlType, FixedHeader, PacketType};
-use control::variable_header::PacketIdentifier;
-use packet::{Packet, PacketError};
-use qos::QualityOfService;
-use topic_name::TopicName;
+use crate::{Decodable, Encodable};
+use crate::control::{ControlType, FixedHeader, PacketType};
+use crate::control::variable_header::PacketIdentifier;
+use crate::packet::{Packet, PacketError};
+use crate::qos::QualityOfService;
+use crate::topic_name::TopicName;
 
 /// QoS with identifier pairs
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Copy, Clone)]
@@ -175,8 +175,8 @@ mod test {
 
     use std::io::Cursor;
 
-    use {Decodable, Encodable};
-    use topic_name::TopicName;
+    use crate::{Decodable, Encodable};
+    use crate::topic_name::TopicName;
 
     #[test]
     fn test_publish_packet_basic() {

--- a/src/packet/publish.rs
+++ b/src/packet/publish.rs
@@ -110,6 +110,13 @@ impl PublishPacket {
     }
 }
 
+// allow reuse of both allocations on incoming PublishPacket
+impl Into<(String, Vec<u8>)> for PublishPacket {
+    fn into(self) -> (String, Vec<u8>) {
+        (self.topic_name().into(), self.payload)
+    }
+}
+
 impl Packet for PublishPacket {
     type Payload = Vec<u8>;
 

--- a/src/packet/pubrec.rs
+++ b/src/packet/pubrec.rs
@@ -2,10 +2,10 @@
 
 use std::io::{Read, Write};
 
-use {Decodable, Encodable};
-use control::{ControlType, FixedHeader, PacketType};
-use control::variable_header::PacketIdentifier;
-use packet::{Packet, PacketError};
+use crate::{Decodable, Encodable};
+use crate::control::{ControlType, FixedHeader, PacketType};
+use crate::control::variable_header::PacketIdentifier;
+use crate::packet::{Packet, PacketError};
 
 /// `PUBREC` packet
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/src/packet/pubrel.rs
+++ b/src/packet/pubrel.rs
@@ -2,10 +2,10 @@
 
 use std::io::{Read, Write};
 
-use {Decodable, Encodable};
-use control::{ControlType, FixedHeader, PacketType};
-use control::variable_header::PacketIdentifier;
-use packet::{Packet, PacketError};
+use crate::{Decodable, Encodable};
+use crate::control::{ControlType, FixedHeader, PacketType};
+use crate::control::variable_header::PacketIdentifier;
+use crate::packet::{Packet, PacketError};
 
 /// `PUBREL` packet
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/src/packet/suback.rs
+++ b/src/packet/suback.rs
@@ -8,11 +8,11 @@ use std::io::{self, Read, Write};
 
 use byteorder::{ReadBytesExt, WriteBytesExt};
 
-use {Decodable, Encodable};
-use control::{ControlType, FixedHeader, PacketType};
-use control::variable_header::PacketIdentifier;
-use packet::{Packet, PacketError};
-use qos::QualityOfService;
+use crate::{Decodable, Encodable};
+use crate::control::{ControlType, FixedHeader, PacketType};
+use crate::control::variable_header::PacketIdentifier;
+use crate::packet::{Packet, PacketError};
+use crate::qos::QualityOfService;
 
 /// Subscribe code
 #[repr(u8)]

--- a/src/packet/subscribe.rs
+++ b/src/packet/subscribe.rs
@@ -8,12 +8,12 @@ use std::string::FromUtf8Error;
 
 use byteorder::{ReadBytesExt, WriteBytesExt};
 
-use {Decodable, Encodable, QualityOfService};
-use control::{ControlType, FixedHeader, PacketType};
-use control::variable_header::PacketIdentifier;
-use encodable::StringEncodeError;
-use packet::{Packet, PacketError};
-use topic_filter::{TopicFilter, TopicFilterError};
+use crate::{Decodable, Encodable, QualityOfService};
+use crate::control::{ControlType, FixedHeader, PacketType};
+use crate::control::variable_header::PacketIdentifier;
+use crate::encodable::StringEncodeError;
+use crate::packet::{Packet, PacketError};
+use crate::topic_filter::{TopicFilter, TopicFilterError};
 
 /// `SUBSCRIBE` packet
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/src/packet/unsuback.rs
+++ b/src/packet/unsuback.rs
@@ -2,10 +2,10 @@
 
 use std::io::{Read, Write};
 
-use {Decodable, Encodable};
-use control::{ControlType, FixedHeader, PacketType};
-use control::variable_header::PacketIdentifier;
-use packet::{Packet, PacketError};
+use crate::{Decodable, Encodable};
+use crate::control::{ControlType, FixedHeader, PacketType};
+use crate::control::variable_header::PacketIdentifier;
+use crate::packet::{Packet, PacketError};
 
 /// `UNSUBACK` packet
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/src/packet/unsubscribe.rs
+++ b/src/packet/unsubscribe.rs
@@ -6,12 +6,12 @@ use std::fmt;
 use std::io::{self, Read, Write};
 use std::string::FromUtf8Error;
 
-use {Decodable, Encodable};
-use control::{ControlType, FixedHeader, PacketType};
-use control::variable_header::PacketIdentifier;
-use encodable::StringEncodeError;
-use packet::{Packet, PacketError};
-use topic_filter::{TopicFilter, TopicFilterError};
+use crate::{Decodable, Encodable};
+use crate::control::{ControlType, FixedHeader, PacketType};
+use crate::control::variable_header::PacketIdentifier;
+use crate::encodable::StringEncodeError;
+use crate::packet::{Packet, PacketError};
+use crate::topic_filter::{TopicFilter, TopicFilterError};
 
 /// `UNSUBSCRIBE` packet
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/src/qos.rs
+++ b/src/qos.rs
@@ -1,6 +1,6 @@
 //! QoS (Quality of Services)
 
-use packet::publish::QoSWithPacketIdentifier;
+use crate::packet::publish::QoSWithPacketIdentifier;
 
 #[repr(u8)]
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Copy, Clone)]

--- a/src/topic_filter.rs
+++ b/src/topic_filter.rs
@@ -9,9 +9,9 @@ use std::ops::Deref;
 
 use regex::Regex;
 
-use {Decodable, Encodable};
-use encodable::StringEncodeError;
-use topic_name::TopicNameRef;
+use crate::{Decodable, Encodable};
+use crate::encodable::StringEncodeError;
+use crate::topic_name::TopicNameRef;
 
 const VALIDATE_TOPIC_FILTER_REGEX: &'static str = r"^(([^+#]*|\+)(/([^+#]*|\+))*(/#)?|#)$";
 

--- a/src/topic_name.rs
+++ b/src/topic_name.rs
@@ -9,8 +9,8 @@ use std::ops::Deref;
 
 use regex::Regex;
 
-use {Decodable, Encodable};
-use encodable::StringEncodeError;
+use crate::{Decodable, Encodable};
+use crate::encodable::StringEncodeError;
 
 const TOPIC_NAME_VALIDATE_REGEX: &'static str = r"^[^#+]+$";
 


### PR DESCRIPTION
CURRENTLY THIS REQUIRES A BETA TOOLCHAIN!

Soon, we will have the new tokio and the new futures and async functions. It would be great to be able to use this most excellent library when that happens :)

I went ahead and ported the code, tests and examples to async fn, futures 0.3 latest alpha and tokio 0.2 latest alpha. I had to bump edition to 2018 with changes accordingly. While at it, I also bumped dependencies to the latest stable versions. I did it all in separate commits, so hopefully, at least some of it could be of use.

It is not a "proper" port, rather, it is the minimum required change for it to compile. It's tested and seems to be working just as well as before. If a "proper" port is of interest, I could easily change the moving of AsyncRead back and forth to mutable borrows etc, but that would make the PR even bigger than it already is, so I refrained from that.

Cheers!