### PR TITLE
Update async/await

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ description = "MQTT Protocol Library"
 keywords = ["mqtt", "protocol"]
 repository = "https://github.com/zonyitoo/mqtt-rs"
 documentation = "https://docs.rs/mqtt-protocol"
+edition = "2018"
 
 [dependencies]
 byteorder = "1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,17 +10,17 @@ documentation = "https://docs.rs/mqtt-protocol"
 edition = "2018"
 
 [dependencies]
-byteorder = "1.2"
+byteorder = "1.3"
 log = "0.4"
-regex = "1.0"
-lazy_static = "1.1"
+regex = "1.3"
+lazy_static = "1.4"
 tokio-io = "0.1"
 futures = "0.1"
 
 [dev-dependencies]
 clap = "2"
-env_logger = "0.5"
-uuid = { version = "0.7", features = ["v4"] }
+env_logger = "0.7"
+uuid = { version = "0.8", features = ["v4"] }
 time = "0.1"
 tokio = "0.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Y. T. Chung <zonyitoo@gmail.com>"]
 name = "mqtt-protocol"
-version = "0.7.0"
+version = "0.8.0"
 license = "MIT/Apache-2.0"
 description = "MQTT Protocol Library"
 keywords = ["mqtt", "protocol"]
@@ -14,15 +14,23 @@ byteorder = "1.3"
 log = "0.4"
 regex = "1.3"
 lazy_static = "1.4"
-tokio-io = "0.1"
-futures = "0.1"
+tokio = { version = "0.2", optional = true }
 
 [dev-dependencies]
 clap = "2"
 env_logger = "0.7"
-uuid = { version = "0.8", features = ["v4"] }
 time = "0.1"
-tokio = "0.1"
+tokio = { version = "0.2", features = ["macros", "rt-threaded", "net", "time", "io-util", "stream"] }
+futures = { version = "0.3" }
+uuid = { version = "0.8", features = ["v4"] }
+
+[features]
+async = ["tokio"]
+default = []
 
 [lib]
 name = "mqtt"
+
+[[example]]
+name = "sub-client-async"
+required-features = ["async"]

--- a/examples/pub-client.rs
+++ b/examples/pub-client.rs
@@ -147,11 +147,11 @@ fn main() {
         let mut line = String::new();
         stdin.read_line(&mut line).unwrap();
 
-        if line.trim_right() == "" {
+        if line.trim_end() == "" {
             continue;
         }
 
-        let message = format!("{}: {}", user_name, line.trim_right());
+        let message = format!("{}: {}", user_name, line.trim_end());
 
         for chan in &channels {
             let publish_packet = PublishPacket::new(chan.clone(), QoSWithPacketIdentifier::Level0, message.clone());

--- a/src/control/fixed_header.rs
+++ b/src/control/fixed_header.rs
@@ -48,6 +48,8 @@ impl FixedHeader {
     #[cfg(feature = "async")]
     /// Asynchronously parse a single fixed header from an AsyncRead type, such as a network
     /// socket.
+    ///
+    /// This requires mqtt-rs to be built with `feature = "async"`
     pub async fn parse<A: AsyncRead + Unpin>(
         rdr: &mut A,
     ) -> Result<(Self, Vec<u8>), FixedHeaderError> {

--- a/src/control/fixed_header.rs
+++ b/src/control/fixed_header.rs
@@ -10,8 +10,8 @@ use byteorder::{ReadBytesExt, WriteBytesExt};
 use futures::{future, Future};
 use tokio_io::{io as async_io, AsyncRead};
 
-use {Decodable, Encodable};
-use control::packet_type::{PacketType, PacketTypeError};
+use crate::{Decodable, Encodable};
+use crate::control::packet_type::{PacketType, PacketTypeError};
 
 /// Fixed header for each MQTT control packet
 ///
@@ -214,8 +214,8 @@ impl Error for FixedHeaderError {
 mod test {
     use super::*;
 
-    use {Decodable, Encodable};
-    use control::packet_type::{ControlType, PacketType};
+    use crate::{Decodable, Encodable};
+    use crate::control::packet_type::{ControlType, PacketType};
     use std::io::Cursor;
 
     #[test]

--- a/src/control/variable_header/connect_ack_flags.rs
+++ b/src/control/variable_header/connect_ack_flags.rs
@@ -3,8 +3,8 @@ use std::io::{Read, Write};
 
 use byteorder::{ReadBytesExt, WriteBytesExt};
 
-use {Decodable, Encodable};
-use control::variable_header::VariableHeaderError;
+use crate::{Decodable, Encodable};
+use crate::control::variable_header::VariableHeaderError;
 
 /// Flags in `CONNACK` packet
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]

--- a/src/control/variable_header/connect_flags.rs
+++ b/src/control/variable_header/connect_flags.rs
@@ -3,8 +3,8 @@ use std::io::{Read, Write};
 
 use byteorder::{ReadBytesExt, WriteBytesExt};
 
-use {Decodable, Encodable};
-use control::variable_header::VariableHeaderError;
+use crate::{Decodable, Encodable};
+use crate::control::variable_header::VariableHeaderError;
 
 /// Flags for `CONNECT` packet
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]

--- a/src/control/variable_header/connect_ret_code.rs
+++ b/src/control/variable_header/connect_ret_code.rs
@@ -3,8 +3,8 @@ use std::io::{Read, Write};
 
 use byteorder::{ReadBytesExt, WriteBytesExt};
 
-use {Decodable, Encodable};
-use control::variable_header::VariableHeaderError;
+use crate::{Decodable, Encodable};
+use crate::control::variable_header::VariableHeaderError;
 
 pub const CONNECTION_ACCEPTED: u8 = 0x00;
 pub const UNACCEPTABLE_PROTOCOL_VERSION: u8 = 0x01;

--- a/src/control/variable_header/keep_alive.rs
+++ b/src/control/variable_header/keep_alive.rs
@@ -3,8 +3,8 @@ use std::io::{Read, Write};
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
-use {Decodable, Encodable};
-use control::variable_header::VariableHeaderError;
+use crate::{Decodable, Encodable};
+use crate::control::variable_header::VariableHeaderError;
 
 /// Keep alive time interval
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]

--- a/src/control/variable_header/mod.rs
+++ b/src/control/variable_header/mod.rs
@@ -6,8 +6,8 @@ use std::fmt;
 use std::io;
 use std::string::FromUtf8Error;
 
-use encodable::StringEncodeError;
-use topic_name::TopicNameError;
+use crate::encodable::StringEncodeError;
+use crate::topic_name::TopicNameError;
 
 pub use self::connect_ack_flags::ConnackFlags;
 pub use self::connect_flags::ConnectFlags;

--- a/src/control/variable_header/packet_identifier.rs
+++ b/src/control/variable_header/packet_identifier.rs
@@ -3,8 +3,8 @@ use std::io::{Read, Write};
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
-use {Decodable, Encodable};
-use control::variable_header::VariableHeaderError;
+use crate::{Decodable, Encodable};
+use crate::control::variable_header::VariableHeaderError;
 
 /// Packet identifier
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]

--- a/src/control/variable_header/protocol_level.rs
+++ b/src/control/variable_header/protocol_level.rs
@@ -5,8 +5,8 @@ use std::io::{Read, Write};
 
 use byteorder::{ReadBytesExt, WriteBytesExt};
 
-use {Decodable, Encodable};
-use control::variable_header::VariableHeaderError;
+use crate::{Decodable, Encodable};
+use crate::control::variable_header::VariableHeaderError;
 
 pub const SPEC_3_1_1: u8 = 0x04;
 

--- a/src/control/variable_header/protocol_name.rs
+++ b/src/control/variable_header/protocol_name.rs
@@ -1,8 +1,8 @@
 use std::convert::From;
 use std::io::{Read, Write};
 
-use {Decodable, Encodable};
-use control::variable_header::VariableHeaderError;
+use crate::{Decodable, Encodable};
+use crate::control::variable_header::VariableHeaderError;
 
 /// Protocol name in variable header
 ///

--- a/src/control/variable_header/topic_name.rs
+++ b/src/control/variable_header/topic_name.rs
@@ -1,9 +1,9 @@
 use std::convert::{From, Into};
 use std::io::{Read, Write};
 
-use {Decodable, Encodable};
-use control::variable_header::VariableHeaderError;
-use topic_name::TopicName;
+use crate::{Decodable, Encodable};
+use crate::control::variable_header::VariableHeaderError;
+use crate::topic_name::TopicName;
 
 /// Topic name wrapper
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,14 +34,6 @@
 //! assert_eq!(VariablePacket::PublishPacket(packet), auto_decode);
 //! ```
 
-extern crate log;
-extern crate byteorder;
-extern crate regex;
-#[macro_use]
-extern crate lazy_static;
-extern crate futures;
-extern crate tokio_io;
-
 pub use self::encodable::{Decodable, Encodable};
 pub use self::qos::QualityOfService;
 pub use self::topic_filter::{TopicFilter, TopicFilterRef};

--- a/src/packet/connack.rs
+++ b/src/packet/connack.rs
@@ -2,10 +2,10 @@
 
 use std::io::{Read, Write};
 
-use {Decodable, Encodable};
-use control::{ControlType, FixedHeader, PacketType};
-use control::variable_header::{ConnackFlags, ConnectReturnCode};
-use packet::{Packet, PacketError};
+use crate::{Decodable, Encodable};
+use crate::control::{ControlType, FixedHeader, PacketType};
+use crate::control::variable_header::{ConnackFlags, ConnectReturnCode};
+use crate::packet::{Packet, PacketError};
 
 /// `CONNACK` packet
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -79,8 +79,8 @@ mod test {
 
     use std::io::Cursor;
 
-    use {Decodable, Encodable};
-    use control::variable_header::ConnectReturnCode;
+    use crate::{Decodable, Encodable};
+    use crate::control::variable_header::ConnectReturnCode;
 
     #[test]
     pub fn test_connack_packet_basic() {

--- a/src/packet/connect.rs
+++ b/src/packet/connect.rs
@@ -4,13 +4,13 @@ use std::error::Error;
 use std::fmt;
 use std::io::{self, Read, Write};
 
-use {Decodable, Encodable};
-use control::{ControlType, FixedHeader, PacketType};
-use control::variable_header::{ConnectFlags, KeepAlive, ProtocolLevel, ProtocolName};
-use control::variable_header::protocol_level::SPEC_3_1_1;
-use encodable::{StringEncodeError, VarBytes};
-use packet::{Packet, PacketError};
-use topic_name::{TopicName, TopicNameError};
+use crate::{Decodable, Encodable};
+use crate::control::{ControlType, FixedHeader, PacketType};
+use crate::control::variable_header::{ConnectFlags, KeepAlive, ProtocolLevel, ProtocolName};
+use crate::control::variable_header::protocol_level::SPEC_3_1_1;
+use crate::encodable::{StringEncodeError, VarBytes};
+use crate::packet::{Packet, PacketError};
+use crate::topic_name::{TopicName, TopicNameError};
 
 /// `CONNECT` packet
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -373,7 +373,7 @@ mod test {
 
     use std::io::Cursor;
 
-    use {Decodable, Encodable};
+    use crate::{Decodable, Encodable};
 
     #[test]
     fn test_connect_packet_encode_basic() {

--- a/src/packet/disconnect.rs
+++ b/src/packet/disconnect.rs
@@ -2,8 +2,8 @@
 
 use std::io::{Read, Write};
 
-use control::{ControlType, FixedHeader, PacketType};
-use packet::{Packet, PacketError};
+use crate::control::{ControlType, FixedHeader, PacketType};
+use crate::packet::{Packet, PacketError};
 
 /// `DISCONNECT` packet
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -3,18 +3,18 @@
 use std::convert::From;
 use std::error::Error;
 use std::fmt;
-use std::io::{self, Read, Write, Cursor};
+use std::io::{self, Read, Write};
 
-use futures::Future;
-use tokio_io::{io as async_io, AsyncRead};
+#[cfg(feature = "async")]
+use tokio::io::{AsyncRead, AsyncReadExt};
 
-use crate::{Decodable, Encodable};
-use crate::control::ControlType;
-use crate::control::FixedHeader;
 use crate::control::fixed_header::FixedHeaderError;
 use crate::control::variable_header::VariableHeaderError;
+use crate::control::ControlType;
+use crate::control::FixedHeader;
 use crate::encodable::StringEncodeError;
 use crate::topic_name::TopicNameError;
+use crate::{Decodable, Encodable};
 
 pub use self::connack::ConnackPacket;
 pub use self::connect::ConnectPacket;
@@ -33,18 +33,18 @@ pub use self::unsubscribe::UnsubscribePacket;
 
 pub use self::publish::QoSWithPacketIdentifier;
 
-pub mod connect;
 pub mod connack;
-pub mod publish;
-pub mod puback;
-pub mod pubrec;
-pub mod pubrel;
-pub mod pubcomp;
+pub mod connect;
+pub mod disconnect;
 pub mod pingreq;
 pub mod pingresp;
-pub mod disconnect;
-pub mod subscribe;
+pub mod puback;
+pub mod pubcomp;
+pub mod publish;
+pub mod pubrec;
+pub mod pubrel;
 pub mod suback;
+pub mod subscribe;
 pub mod unsuback;
 pub mod unsubscribe;
 
@@ -64,7 +64,10 @@ pub trait Packet: Sized {
     /// Length of bytes after encoding variable header
     fn encoded_variable_headers_length(&self) -> u32;
     /// Deocde packet with a `FixedHeader`
-    fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>>;
+    fn decode_packet<R: Read>(
+        reader: &mut R,
+        fixed_header: FixedHeader,
+    ) -> Result<Self, PacketError<Self>>;
 }
 
 impl<T: Packet + fmt::Debug + 'static> Encodable for T {
@@ -80,7 +83,9 @@ impl<T: Packet + fmt::Debug + 'static> Encodable for T {
     }
 
     fn encoded_length(&self) -> u32 {
-        self.fixed_header().encoded_length() + self.encoded_variable_headers_length() + self.payload_ref().encoded_length()
+        self.fixed_header().encoded_length()
+            + self.encoded_variable_headers_length()
+            + self.payload_ref().encoded_length()
     }
 }
 
@@ -88,7 +93,10 @@ impl<T: Packet + fmt::Debug + 'static> Decodable for T {
     type Err = PacketError<T>;
     type Cond = FixedHeader;
 
-    fn decode_with<R: Read>(reader: &mut R, fixed_header: Option<FixedHeader>) -> Result<Self, PacketError<Self>> {
+    fn decode_with<R: Read>(
+        reader: &mut R,
+        fixed_header: Option<FixedHeader>,
+    ) -> Result<Self, PacketError<Self>> {
         let fixed_header: FixedHeader = if let Some(hdr) = fixed_header {
             hdr
         } else {
@@ -191,68 +199,66 @@ macro_rules! impl_variable_packet {
             )+
         }
 
+        #[cfg(feature = "async")]
         impl VariablePacket {
-            pub fn peek<A: AsyncRead>(rdr: A) -> impl Future<Item = (A, FixedHeader, Vec<u8>), Error = VariablePacketError> {
-                FixedHeader::parse(rdr).then(|result| {
-                    let (rdr, fixed_header, data) = match result {
-                        Ok((rdr, header, data)) => (rdr, header, data),
-                        Err(FixedHeaderError::Unrecognized(code, _length)) => {
-                            // can't read excess bytes from rdr as it was dropped when an error
-                            // occurred
-                            return Err(VariablePacketError::UnrecognizedPacket(code, Vec::new()));
-                        },
-                        Err(FixedHeaderError::ReservedType(code, _length)) => {
-                            // can't read excess bytes from rdr as it was dropped when an error
-                            // occurred
-                            return Err(VariablePacketError::ReservedPacket(code, Vec::new()));
-                        },
-                        Err(err) => return Err(From::from(err))
-                    };
+            pub async fn peek<A: AsyncRead + Unpin>(rdr: &mut A) -> Result<(FixedHeader, Vec<u8>), VariablePacketError> {
+                let result = FixedHeader::parse(rdr).await;
 
-                    Ok((rdr, fixed_header, data))
-                })
-            }
-            pub fn peek_finalize<A: AsyncRead>(rdr: A) -> impl Future<Item = (A, Vec<u8>, Self), Error = VariablePacketError> {
-                Self::peek(rdr).and_then(|(rdr, fixed_header, header_buffer)| {
-                    let packet = vec![0u8; fixed_header.remaining_length as usize];
-                    async_io::read_exact(rdr, packet)
-                        .from_err()
-                        .and_then(move |(rdr, packet)| {
-                            let mut buff_rdr = Cursor::new(packet.clone());
-                            let output = match fixed_header.packet_type.control_type {
-                                $(
-                                    ControlType::$hdr => {
-                                        let pk = <$name as Packet>::decode_packet(&mut buff_rdr, fixed_header)?;
-                                        VariablePacket::$name(pk)
-                                    }
-                                )+
-                            };
-                            let mut result = Vec::new();
-                            result.extend(header_buffer);
-                            result.extend(packet);
-                            Ok((rdr, result, output))
-                        })
-                })
-            }
-            pub fn parse<A: AsyncRead>(rdr: A) -> impl Future<Item = (A, Self), Error = VariablePacketError> {
-                Self::peek(rdr).and_then(|(rdr, fixed_header, _)| {
-                    let buffer = vec![0u8; fixed_header.remaining_length as usize];
-                    async_io::read_exact(rdr, buffer)
-                        .from_err()
-                        .and_then(move |(rdr, buffer)| {
-                            let mut buff_rdr = Cursor::new(buffer);
-                            let output = match fixed_header.packet_type.control_type {
-                                $(
-                                    ControlType::$hdr => {
-                                        let pk = <$name as Packet>::decode_packet(&mut buff_rdr, fixed_header)?;
-                                        VariablePacket::$name(pk)
-                                    }
-                                )+
-                            };
+                let (fixed_header, data) = match result {
+                    Ok((header, data)) => (header, data),
+                    Err(FixedHeaderError::Unrecognized(code, _length)) => {
+                        // TODO: Could read/drop excess bytes from rdr, if you want
+                        return Err(VariablePacketError::UnrecognizedPacket(code, Vec::new()));
+                    },
+                    Err(FixedHeaderError::ReservedType(code, _length)) => {
+                        // TODO: Could read/drop excess bytes from rdr, if you want
+                        return Err(VariablePacketError::ReservedPacket(code, Vec::new()));
+                    },
+                    Err(err) => return Err(From::from(err))
+                };
 
-                            Ok((rdr, output))
-                        })
-                })
+                Ok((fixed_header, data))
+            }
+
+            pub async fn peek_finalize<A: AsyncRead + Unpin>(rdr: &mut A) -> Result<(Vec<u8>, Self), VariablePacketError> {
+                use std::io::Cursor;
+                let (fixed_header, mut result) = Self::peek(rdr).await?;
+
+                let mut packet = vec![0u8; fixed_header.remaining_length as usize];
+                rdr.read_exact(&mut packet).await?;
+
+                let mut buff_rdr = Cursor::new(packet.clone());
+                let output = match fixed_header.packet_type.control_type {
+                    $(
+                        ControlType::$hdr => {
+                            let pk = <$name as Packet>::decode_packet(&mut buff_rdr, fixed_header)?;
+                            VariablePacket::$name(pk)
+                        }
+                    )+
+                };
+
+                result.extend(packet);
+                Ok((result, output))
+            }
+
+            pub async fn parse<A: AsyncRead + Unpin>(rdr: &mut A) -> Result<Self, VariablePacketError> {
+                use std::io::Cursor;
+                let (fixed_header, _) = Self::peek(rdr).await?;
+
+                let mut buffer = vec![0u8; fixed_header.remaining_length as usize];
+                rdr.read_exact(&mut buffer).await?;
+
+                let mut buff_rdr = Cursor::new(buffer);
+                let output = match fixed_header.packet_type.control_type {
+                    $(
+                        ControlType::$hdr => {
+                            let pk = <$name as Packet>::decode_packet(&mut buff_rdr, fixed_header)?;
+                            VariablePacket::$name(pk)
+                        }
+                    )+
+                };
+
+                Ok(output)
             }
         }
 
@@ -457,9 +463,9 @@ mod test {
         assert_eq!(var_packet, decoded_packet);
     }
 
-    #[test]
-    fn test_variable_packet_async_parse() {
-        use std::io::Cursor;
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn test_variable_packet_async_parse() {
         let packet = ConnectPacket::new("MQTT".to_owned(), "1234".to_owned());
 
         // Wrap it
@@ -470,16 +476,15 @@ mod test {
         var_packet.encode(&mut buf).unwrap();
 
         // Parse
-        let async_buf = Cursor::new(buf);
-        match VariablePacket::parse(async_buf).wait() {
-            Err(_) => assert!(false),
-            Ok((_, decoded_packet)) => assert_eq!(var_packet, decoded_packet),
-        }
+        let mut async_buf = buf.as_slice();
+        let decoded_packet =  VariablePacket::parse(&mut async_buf).await.unwrap();
+
+        assert_eq!(var_packet, decoded_packet);
     }
 
-    #[test]
-    fn test_variable_packet_async_peek() {
-        use std::io::Cursor;
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn test_variable_packet_async_peek() {
         let packet = ConnectPacket::new("MQTT".to_owned(), "1234".to_owned());
 
         // Wrap it
@@ -490,20 +495,17 @@ mod test {
         var_packet.encode(&mut buf).unwrap();
 
         // Peek
-        let async_buf = Cursor::new(buf.clone());
-        match VariablePacket::peek(async_buf.clone()).wait() {
-            Err(_) => assert!(false),
-            Ok((_, fixed_header, _)) => assert_eq!(fixed_header.packet_type.control_type, ControlType::Connect),
-        }
+        let mut async_buf = buf.as_slice();
+        let (fixed_header, _) = VariablePacket::peek(&mut async_buf).await.unwrap();
+
+        assert_eq!(fixed_header.packet_type.control_type, ControlType::Connect);
 
         // Read the rest
-        match VariablePacket::peek_finalize(async_buf).wait() {
-            Err(_) => assert!(false),
-            Ok((_, peeked_buffer, peeked_packet)) => {
-                assert_eq!(peeked_buffer, buf);
-                assert_eq!(peeked_packet, var_packet);
-            }
-        }
-    }
+        let mut async_buf = buf.as_slice();
+        let (peeked_buffer, peeked_packet) =
+            VariablePacket::peek_finalize(&mut async_buf).await.unwrap();
 
+        assert_eq!(peeked_buffer, buf);
+        assert_eq!(peeked_packet, var_packet);
+    }
 }

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -298,13 +298,13 @@ macro_rules! impl_variable_packet {
                             Err(FixedHeaderError::Unrecognized(code, length)) => {
                                 let reader = &mut reader.take(length as u64);
                                 let mut buf = Vec::with_capacity(length as usize);
-                                try!(reader.read_to_end(&mut buf));
+                                reader.read_to_end(&mut buf)?;
                                 return Err(VariablePacketError::UnrecognizedPacket(code, buf));
                             },
                             Err(FixedHeaderError::ReservedType(code, length)) => {
                                 let reader = &mut reader.take(length as u64);
                                 let mut buf = Vec::with_capacity(length as usize);
-                                try!(reader.read_to_end(&mut buf));
+                                reader.read_to_end(&mut buf)?;
                                 return Err(VariablePacketError::ReservedPacket(code, buf));
                             },
                             Err(err) => return Err(From::from(err))
@@ -316,7 +316,7 @@ macro_rules! impl_variable_packet {
                 match fixed_header.packet_type.control_type {
                     $(
                         ControlType::$hdr => {
-                            let pk = try!(<$name as Packet>::decode_packet(reader, fixed_header));
+                            let pk = <$name as Packet>::decode_packet(reader, fixed_header)?;
                             Ok(VariablePacket::$name(pk))
                         }
                     )+

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -8,13 +8,13 @@ use std::io::{self, Read, Write, Cursor};
 use futures::Future;
 use tokio_io::{io as async_io, AsyncRead};
 
-use {Decodable, Encodable};
-use control::ControlType;
-use control::FixedHeader;
-use control::fixed_header::FixedHeaderError;
-use control::variable_header::VariableHeaderError;
-use encodable::StringEncodeError;
-use topic_name::TopicNameError;
+use crate::{Decodable, Encodable};
+use crate::control::ControlType;
+use crate::control::FixedHeader;
+use crate::control::fixed_header::FixedHeaderError;
+use crate::control::variable_header::VariableHeaderError;
+use crate::encodable::StringEncodeError;
+use crate::topic_name::TopicNameError;
 
 pub use self::connack::ConnackPacket;
 pub use self::connect::ConnectPacket;
@@ -437,7 +437,7 @@ mod test {
 
     use std::io::Cursor;
 
-    use {Decodable, Encodable};
+    use crate::{Decodable, Encodable};
 
     #[test]
     fn test_variable_packet_basic() {

--- a/src/packet/pingreq.rs
+++ b/src/packet/pingreq.rs
@@ -2,8 +2,8 @@
 
 use std::io::{Read, Write};
 
-use control::{ControlType, FixedHeader, PacketType};
-use packet::{Packet, PacketError};
+use crate::control::{ControlType, FixedHeader, PacketType};
+use crate::packet::{Packet, PacketError};
 
 /// `PINGREQ` packet
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/src/packet/pingresp.rs
+++ b/src/packet/pingresp.rs
@@ -2,8 +2,8 @@
 
 use std::io::{Read, Write};
 
-use control::{ControlType, FixedHeader, PacketType};
-use packet::{Packet, PacketError};
+use crate::control::{ControlType, FixedHeader, PacketType};
+use crate::packet::{Packet, PacketError};
 
 /// `PINGRESP` packet
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/src/packet/puback.rs
+++ b/src/packet/puback.rs
@@ -2,10 +2,10 @@
 
 use std::io::{Read, Write};
 
-use {Decodable, Encodable};
-use control::{ControlType, FixedHeader, PacketType};
-use control::variable_header::PacketIdentifier;
-use packet::{Packet, PacketError};
+use crate::{Decodable, Encodable};
+use crate::control::{ControlType, FixedHeader, PacketType};
+use crate::control::variable_header::PacketIdentifier;
+use crate::packet::{Packet, PacketError};
 
 /// `PUBACK` packet
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/src/packet/pubcomp.rs
+++ b/src/packet/pubcomp.rs
@@ -2,10 +2,10 @@
 
 use std::io::{Read, Write};
 
-use {Decodable, Encodable};
-use control::{ControlType, FixedHeader, PacketType};
-use control::variable_header::PacketIdentifier;
-use packet::{Packet, PacketError};
+use crate::{Decodable, Encodable};
+use crate::control::{ControlType, FixedHeader, PacketType};
+use crate::control::variable_header::PacketIdentifier;
+use crate::packet::{Packet, PacketError};
 
 /// `PUBCOMP` packet
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/src/packet/publish.rs
+++ b/src/packet/publish.rs
@@ -2,12 +2,12 @@
 
 use std::io::{Read, Write};
 
-use {Decodable, Encodable};
-use control::{ControlType, FixedHeader, PacketType};
-use control::variable_header::PacketIdentifier;
-use packet::{Packet, PacketError};
-use qos::QualityOfService;
-use topic_name::TopicName;
+use crate::{Decodable, Encodable};
+use crate::control::{ControlType, FixedHeader, PacketType};
+use crate::control::variable_header::PacketIdentifier;
+use crate::packet::{Packet, PacketError};
+use crate::qos::QualityOfService;
+use crate::topic_name::TopicName;
 
 /// QoS with identifier pairs
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Copy, Clone)]
@@ -175,8 +175,8 @@ mod test {
 
     use std::io::Cursor;
 
-    use {Decodable, Encodable};
-    use topic_name::TopicName;
+    use crate::{Decodable, Encodable};
+    use crate::topic_name::TopicName;
 
     #[test]
     fn test_publish_packet_basic() {

--- a/src/packet/pubrec.rs
+++ b/src/packet/pubrec.rs
@@ -2,10 +2,10 @@
 
 use std::io::{Read, Write};
 
-use {Decodable, Encodable};
-use control::{ControlType, FixedHeader, PacketType};
-use control::variable_header::PacketIdentifier;
-use packet::{Packet, PacketError};
+use crate::{Decodable, Encodable};
+use crate::control::{ControlType, FixedHeader, PacketType};
+use crate::control::variable_header::PacketIdentifier;
+use crate::packet::{Packet, PacketError};
 
 /// `PUBREC` packet
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/src/packet/pubrel.rs
+++ b/src/packet/pubrel.rs
@@ -2,10 +2,10 @@
 
 use std::io::{Read, Write};
 
-use {Decodable, Encodable};
-use control::{ControlType, FixedHeader, PacketType};
-use control::variable_header::PacketIdentifier;
-use packet::{Packet, PacketError};
+use crate::{Decodable, Encodable};
+use crate::control::{ControlType, FixedHeader, PacketType};
+use crate::control::variable_header::PacketIdentifier;
+use crate::packet::{Packet, PacketError};
 
 /// `PUBREL` packet
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/src/packet/suback.rs
+++ b/src/packet/suback.rs
@@ -8,11 +8,11 @@ use std::io::{self, Read, Write};
 
 use byteorder::{ReadBytesExt, WriteBytesExt};
 
-use {Decodable, Encodable};
-use control::{ControlType, FixedHeader, PacketType};
-use control::variable_header::PacketIdentifier;
-use packet::{Packet, PacketError};
-use qos::QualityOfService;
+use crate::{Decodable, Encodable};
+use crate::control::{ControlType, FixedHeader, PacketType};
+use crate::control::variable_header::PacketIdentifier;
+use crate::packet::{Packet, PacketError};
+use crate::qos::QualityOfService;
 
 /// Subscribe code
 #[repr(u8)]

--- a/src/packet/subscribe.rs
+++ b/src/packet/subscribe.rs
@@ -8,12 +8,12 @@ use std::string::FromUtf8Error;
 
 use byteorder::{ReadBytesExt, WriteBytesExt};
 
-use {Decodable, Encodable, QualityOfService};
-use control::{ControlType, FixedHeader, PacketType};
-use control::variable_header::PacketIdentifier;
-use encodable::StringEncodeError;
-use packet::{Packet, PacketError};
-use topic_filter::{TopicFilter, TopicFilterError};
+use crate::{Decodable, Encodable, QualityOfService};
+use crate::control::{ControlType, FixedHeader, PacketType};
+use crate::control::variable_header::PacketIdentifier;
+use crate::encodable::StringEncodeError;
+use crate::packet::{Packet, PacketError};
+use crate::topic_filter::{TopicFilter, TopicFilterError};
 
 /// `SUBSCRIBE` packet
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/src/packet/unsuback.rs
+++ b/src/packet/unsuback.rs
@@ -2,10 +2,10 @@
 
 use std::io::{Read, Write};
 
-use {Decodable, Encodable};
-use control::{ControlType, FixedHeader, PacketType};
-use control::variable_header::PacketIdentifier;
-use packet::{Packet, PacketError};
+use crate::{Decodable, Encodable};
+use crate::control::{ControlType, FixedHeader, PacketType};
+use crate::control::variable_header::PacketIdentifier;
+use crate::packet::{Packet, PacketError};
 
 /// `UNSUBACK` packet
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/src/packet/unsubscribe.rs
+++ b/src/packet/unsubscribe.rs
@@ -6,12 +6,12 @@ use std::fmt;
 use std::io::{self, Read, Write};
 use std::string::FromUtf8Error;
 
-use {Decodable, Encodable};
-use control::{ControlType, FixedHeader, PacketType};
-use control::variable_header::PacketIdentifier;
-use encodable::StringEncodeError;
-use packet::{Packet, PacketError};
-use topic_filter::{TopicFilter, TopicFilterError};
+use crate::{Decodable, Encodable};
+use crate::control::{ControlType, FixedHeader, PacketType};
+use crate::control::variable_header::PacketIdentifier;
+use crate::encodable::StringEncodeError;
+use crate::packet::{Packet, PacketError};
+use crate::topic_filter::{TopicFilter, TopicFilterError};
 
 /// `UNSUBSCRIBE` packet
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/src/qos.rs
+++ b/src/qos.rs
@@ -1,6 +1,6 @@
 //! QoS (Quality of Services)
 
-use packet::publish::QoSWithPacketIdentifier;
+use crate::packet::publish::QoSWithPacketIdentifier;
 
 #[repr(u8)]
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Copy, Clone)]

--- a/src/topic_filter.rs
+++ b/src/topic_filter.rs
@@ -7,11 +7,12 @@ use std::io::{Read, Write};
 use std::mem;
 use std::ops::Deref;
 
+use lazy_static::lazy_static;
 use regex::Regex;
 
-use {Decodable, Encodable};
-use encodable::StringEncodeError;
-use topic_name::TopicNameRef;
+use crate::{Decodable, Encodable};
+use crate::encodable::StringEncodeError;
+use crate::topic_name::TopicNameRef;
 
 const VALIDATE_TOPIC_FILTER_REGEX: &'static str = r"^(([^+#]*|\+)(/([^+#]*|\+))*(/#)?|#)$";
 

--- a/src/topic_name.rs
+++ b/src/topic_name.rs
@@ -7,10 +7,11 @@ use std::io::{Read, Write};
 use std::mem;
 use std::ops::Deref;
 
+use lazy_static::lazy_static;
 use regex::Regex;
 
-use {Decodable, Encodable};
-use encodable::StringEncodeError;
+use crate::{Decodable, Encodable};
+use crate::encodable::StringEncodeError;
 
 const TOPIC_NAME_VALIDATE_REGEX: &'static str = r"^[^#+]+$";
 


### PR DESCRIPTION
Since AsyncRead doesn't match between futures 0.3 and tokio 0.2, I've gated the async features behind a feature flag so as to not introduce dependencies on tokio unless necessary. This approach effectively removes the dependency for those not using async features (there are only two async functions that really make any sense to expose anyway).