### PR TITLE
Add getters for protocol version and name; default to "MQTT" for name

### DIFF
--- a/examples/pub-client.rs
+++ b/examples/pub-client.rs
@@ -81,7 +81,7 @@ fn main() {
     info!("Connected!");
 
     info!("Client identifier {:?}", client_id);
-    let mut conn = ConnectPacket::new("MQTT", client_id);
+    let mut conn = ConnectPacket::new(client_id);
     conn.set_clean_session(true);
     let mut buf = Vec::new();
     conn.encode(&mut buf).unwrap();

--- a/examples/sub-client-async.rs
+++ b/examples/sub-client-async.rs
@@ -97,7 +97,7 @@ async fn main() {
     info!("Connected!");
 
     info!("Client identifier {:?}", client_id);
-    let mut conn = ConnectPacket::new("MQTT", client_id);
+    let mut conn = ConnectPacket::new(client_id);
     conn.set_clean_session(true);
     conn.set_keep_alive(keep_alive);
     let mut buf = Vec::new();

--- a/examples/sub-client.rs
+++ b/examples/sub-client.rs
@@ -87,7 +87,7 @@ fn main() {
     info!("Connected!");
 
     info!("Client identifier {:?}", client_id);
-    let mut conn = ConnectPacket::new("MQTT", client_id);
+    let mut conn = ConnectPacket::new(client_id);
     conn.set_clean_session(true);
     conn.set_keep_alive(keep_alive);
     let mut buf = Vec::new();

--- a/src/control/variable_header/mod.rs
+++ b/src/control/variable_header/mod.rs
@@ -35,6 +35,7 @@ pub enum VariableHeaderError {
     InvalidReservedFlag,
     FromUtf8Error(FromUtf8Error),
     TopicNameError(TopicNameError),
+    InvalidProtocolVersion,
 }
 
 impl From<io::Error> for VariableHeaderError {
@@ -69,6 +70,7 @@ impl fmt::Display for VariableHeaderError {
             VariableHeaderError::InvalidReservedFlag => write!(f, "Invalid reserved flags"),
             VariableHeaderError::FromUtf8Error(ref err) => write!(f, "{}", err),
             VariableHeaderError::TopicNameError(ref err) => write!(f, "{}", err),
+            VariableHeaderError::InvalidProtocolVersion => write!(f, "Invalid protocol version"),
         }
     }
 }
@@ -81,6 +83,7 @@ impl Error for VariableHeaderError {
             VariableHeaderError::InvalidReservedFlag => None,
             VariableHeaderError::FromUtf8Error(ref err) => Some(err),
             VariableHeaderError::TopicNameError(ref err) => Some(err),
+            VariableHeaderError::InvalidProtocolVersion => None,
         }
     }
 }

--- a/src/control/variable_header/protocol_level.rs
+++ b/src/control/variable_header/protocol_level.rs
@@ -5,20 +5,27 @@ use std::io::{Read, Write};
 
 use byteorder::{ReadBytesExt, WriteBytesExt};
 
-use crate::{Decodable, Encodable};
 use crate::control::variable_header::VariableHeaderError;
+use crate::{Decodable, Encodable};
 
+pub const SPEC_3_1_0: u8 = 0x03;
 pub const SPEC_3_1_1: u8 = 0x04;
+pub const SPEC_5_0: u8 = 0x05;
 
 /// Protocol level in MQTT (`0x04` in v3.1.1)
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
-pub struct ProtocolLevel(pub u8);
+#[repr(u8)]
+pub enum ProtocolLevel {
+    Version310 = SPEC_3_1_0,
+    Version311 = SPEC_3_1_1,
+    Version50 = SPEC_5_0,
+}
 
 impl Encodable for ProtocolLevel {
     type Err = VariableHeaderError;
 
     fn encode<W: Write>(&self, writer: &mut W) -> Result<(), VariableHeaderError> {
-        writer.write_u8(self.0).map_err(From::from)
+        writer.write_u8(*self as u8).map_err(From::from)
     }
 
     fn encoded_length(&self) -> u32 {
@@ -31,6 +38,21 @@ impl Decodable for ProtocolLevel {
     type Cond = ();
 
     fn decode_with<R: Read>(reader: &mut R, _rest: Option<()>) -> Result<ProtocolLevel, VariableHeaderError> {
-        reader.read_u8().map(ProtocolLevel).map_err(From::from)
+        reader
+            .read_u8()
+            .map_err(From::from)
+            .map(ProtocolLevel::from_u8)
+            .and_then(|x| x.ok_or(VariableHeaderError::InvalidProtocolVersion))
+    }
+}
+
+impl ProtocolLevel {
+    pub fn from_u8(n: u8) -> Option<ProtocolLevel> {
+        match n {
+            SPEC_3_1_0 => Some(ProtocolLevel::Version310),
+            SPEC_3_1_1 => Some(ProtocolLevel::Version311),
+            SPEC_5_0 => Some(ProtocolLevel::Version50),
+            _ => None,
+        }
     }
 }

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -430,7 +430,7 @@ mod test {
 
     #[test]
     fn test_variable_packet_basic() {
-        let packet = ConnectPacket::new("MQTT".to_owned(), "1234".to_owned());
+        let packet = ConnectPacket::new("1234".to_owned());
 
         // Wrap it
         let var_packet = VariablePacket::new(packet);
@@ -449,7 +449,7 @@ mod test {
     #[cfg(feature = "async")]
     #[tokio::test]
     async fn test_variable_packet_async_parse() {
-        let packet = ConnectPacket::new("MQTT".to_owned(), "1234".to_owned());
+        let packet = ConnectPacket::new("1234".to_owned());
 
         // Wrap it
         let var_packet = VariablePacket::new(packet);
@@ -468,7 +468,7 @@ mod test {
     #[cfg(feature = "async")]
     #[tokio::test]
     async fn test_variable_packet_async_peek() {
-        let packet = ConnectPacket::new("MQTT".to_owned(), "1234".to_owned());
+        let packet = ConnectPacket::new("1234".to_owned());
 
         // Wrap it
         let var_packet = VariablePacket::new(packet);


### PR DESCRIPTION
MQTT broker implementations are required to verify that the protocol name and version are correct before accepting connections, so this PR provides a way to access those fields.

I've also removed a field from `ConnectPacket::new` that doesn't really make sense: the protocol name for 3.1.1 going forward must always be "MQTT". Users can still use `with_level` if they want to specify version and name manually (i.e. to use "MQISDP" for a 3.1.0 client, or to provide invalid sequences for broker testing). This is a breaking API change, but updating should be pretty trivial for most users.