### PR TITLE
Add a tokio_util::codec::Encoder/Decoder implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ log = "0.4"
 regex = "1.3"
 lazy_static = "1.4"
 tokio = { version = "1.0", optional = true }
+tokio-util = { version = "0.6", features = ["codec"], optional = true }
+bytes = { version = "1.0", optional = true }
 
 [dev-dependencies]
 clap = "2"
@@ -26,6 +28,7 @@ uuid = { version = "0.8", features = ["v4"] }
 
 [features]
 async = ["tokio"]
+tokio-codec = ["async", "tokio-util", "bytes"]
 default = []
 
 [lib]

--- a/examples/pub-client.rs
+++ b/examples/pub-client.rs
@@ -1,9 +1,5 @@
-extern crate mqtt;
 #[macro_use]
 extern crate log;
-extern crate clap;
-extern crate env_logger;
-extern crate uuid;
 
 use std::env;
 use std::io::{self, Write};

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,5 +1,3 @@
-extern crate mqtt;
-
 use std::io::Cursor;
 
 use mqtt::packet::{PublishPacket, QoSWithPacketIdentifier, VariablePacket};

--- a/examples/sub-client-async.rs
+++ b/examples/sub-client-async.rs
@@ -10,9 +10,8 @@ use log::{error, info, trace};
 use uuid::Uuid;
 
 use futures::join;
-use futures::prelude::*;
+use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
-use tokio::prelude::*;
 
 use mqtt::control::variable_header::ConnectReturnCode;
 use mqtt::packet::*;
@@ -141,7 +140,9 @@ async fn main() {
     let mut ping_stream = tokio::time::interval(ping_time);
 
     let ping_sender = async move {
-        while ping_stream.next().await.is_some() {
+        loop {
+            ping_stream.tick().await;
+
             info!("Sending PINGREQ to broker");
 
             let pingreq_packet = PingreqPacket::new();

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
+edition = "2018"
 max_width = 120
 reorder_imports = true
 use_try_shorthand = true


### PR DESCRIPTION
I did make a breaking change in the signature of `FixedHeader::parse`, but given that the `VariablePacket::peek*` methods weren't exposed anyway, I figured it would at least make things consistent.