### PR TITLE
Rework Encodable and Packet traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ lazy_static = "1.4"
 tokio = { version = "1.0", optional = true }
 tokio-util = { version = "0.6", features = ["codec"], optional = true }
 bytes = { version = "1.0", optional = true }
+thiserror = "1.0"
 
 [dev-dependencies]
 clap = "2"
@@ -27,8 +28,7 @@ futures = { version = "0.3" }
 uuid = { version = "0.8", features = ["v4"] }
 
 [features]
-async = ["tokio"]
-tokio-codec = ["async", "tokio-util", "bytes"]
+tokio-codec = ["tokio", "tokio-util", "bytes"]
 default = []
 
 [lib]
@@ -36,4 +36,4 @@ name = "mqtt"
 
 [[example]]
 name = "sub-client-async"
-required-features = ["async"]
+required-features = ["tokio"]

--- a/src/control/packet_type.rs
+++ b/src/control/packet_type.rs
@@ -1,8 +1,5 @@
 //! Packet types
 
-use std::error::Error;
-use std::fmt;
-
 /// Packet type
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub struct PacketType {
@@ -144,24 +141,15 @@ impl PacketType {
 }
 
 /// Parsing packet type errors
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum PacketTypeError {
+    #[error("reserved type {0:?} ({1:#X})")]
     ReservedType(u8, u8),
+    #[error("undefined type {0:?} ({1:#X})")]
     UndefinedType(u8, u8),
+    #[error("invalid flag for {0:?} ({1:#X})")]
     InvalidFlag(ControlType, u8),
 }
-
-impl fmt::Display for PacketTypeError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            PacketTypeError::ReservedType(t, flag) => write!(f, "Reserved type {:?} ({:#X})", t, flag),
-            PacketTypeError::InvalidFlag(t, flag) => write!(f, "Invalid flag for {:?} ({:#X})", t, flag),
-            PacketTypeError::UndefinedType(t, flag) => write!(f, "Undefined type {:?} ({:#X})", t, flag),
-        }
-    }
-}
-
-impl Error for PacketTypeError {}
 
 #[rustfmt::skip]
 mod value {

--- a/src/control/variable_header/connect_ack_flags.rs
+++ b/src/control/variable_header/connect_ack_flags.rs
@@ -1,5 +1,4 @@
-use std::convert::From;
-use std::io::{Read, Write};
+use std::io::{self, Read, Write};
 
 use byteorder::{ReadBytesExt, WriteBytesExt};
 
@@ -19,11 +18,9 @@ impl ConnackFlags {
 }
 
 impl Encodable for ConnackFlags {
-    type Err = VariableHeaderError;
-
-    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), VariableHeaderError> {
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
         let code = self.session_present as u8;
-        writer.write_u8(code).map_err(From::from)
+        writer.write_u8(code)
     }
 
     fn encoded_length(&self) -> u32 {
@@ -32,10 +29,10 @@ impl Encodable for ConnackFlags {
 }
 
 impl Decodable for ConnackFlags {
-    type Err = VariableHeaderError;
+    type Error = VariableHeaderError;
     type Cond = ();
 
-    fn decode_with<R: Read>(reader: &mut R, _rest: Option<()>) -> Result<ConnackFlags, VariableHeaderError> {
+    fn decode_with<R: Read>(reader: &mut R, _rest: ()) -> Result<ConnackFlags, VariableHeaderError> {
         let code = reader.read_u8()?;
         if code & !1 != 0 {
             return Err(VariableHeaderError::InvalidReservedFlag);

--- a/src/control/variable_header/connect_flags.rs
+++ b/src/control/variable_header/connect_flags.rs
@@ -1,5 +1,4 @@
-use std::convert::From;
-use std::io::{Read, Write};
+use std::io::{self, Read, Write};
 
 use byteorder::{ReadBytesExt, WriteBytesExt};
 
@@ -34,10 +33,8 @@ impl ConnectFlags {
 }
 
 impl Encodable for ConnectFlags {
-    type Err = VariableHeaderError;
-
     #[rustfmt::skip]
-    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), VariableHeaderError> {
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
         let code = ((self.user_name as u8) << 7)
             | ((self.password as u8) << 6)
             | ((self.will_retain as u8) << 5)
@@ -45,7 +42,7 @@ impl Encodable for ConnectFlags {
             | ((self.will_flag as u8) << 2)
             | ((self.clean_session as u8) << 1);
 
-        writer.write_u8(code).map_err(From::from)
+        writer.write_u8(code)
     }
 
     fn encoded_length(&self) -> u32 {
@@ -54,10 +51,10 @@ impl Encodable for ConnectFlags {
 }
 
 impl Decodable for ConnectFlags {
-    type Err = VariableHeaderError;
+    type Error = VariableHeaderError;
     type Cond = ();
 
-    fn decode_with<R: Read>(reader: &mut R, _rest: Option<()>) -> Result<ConnectFlags, VariableHeaderError> {
+    fn decode_with<R: Read>(reader: &mut R, _rest: ()) -> Result<ConnectFlags, VariableHeaderError> {
         let code = reader.read_u8()?;
         if code & 1 != 0 {
             return Err(VariableHeaderError::InvalidReservedFlag);

--- a/src/control/variable_header/connect_ret_code.rs
+++ b/src/control/variable_header/connect_ret_code.rs
@@ -1,5 +1,4 @@
-use std::convert::From;
-use std::io::{Read, Write};
+use std::io::{self, Read, Write};
 
 use byteorder::{ReadBytesExt, WriteBytesExt};
 
@@ -54,10 +53,8 @@ impl ConnectReturnCode {
 }
 
 impl Encodable for ConnectReturnCode {
-    type Err = VariableHeaderError;
-
-    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), VariableHeaderError> {
-        writer.write_u8(self.to_u8()).map_err(From::from)
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
+        writer.write_u8(self.to_u8())
     }
 
     fn encoded_length(&self) -> u32 {
@@ -66,10 +63,10 @@ impl Encodable for ConnectReturnCode {
 }
 
 impl Decodable for ConnectReturnCode {
-    type Err = VariableHeaderError;
+    type Error = VariableHeaderError;
     type Cond = ();
 
-    fn decode_with<R: Read>(reader: &mut R, _rest: Option<()>) -> Result<ConnectReturnCode, VariableHeaderError> {
+    fn decode_with<R: Read>(reader: &mut R, _rest: ()) -> Result<ConnectReturnCode, VariableHeaderError> {
         reader.read_u8().map(ConnectReturnCode::from_u8).map_err(From::from)
     }
 }

--- a/src/control/variable_header/keep_alive.rs
+++ b/src/control/variable_header/keep_alive.rs
@@ -1,5 +1,4 @@
-use std::convert::From;
-use std::io::{Read, Write};
+use std::io::{self, Read, Write};
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
@@ -11,10 +10,8 @@ use crate::{Decodable, Encodable};
 pub struct KeepAlive(pub u16);
 
 impl Encodable for KeepAlive {
-    type Err = VariableHeaderError;
-
-    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), VariableHeaderError> {
-        writer.write_u16::<BigEndian>(self.0).map_err(From::from)
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
+        writer.write_u16::<BigEndian>(self.0)
     }
 
     fn encoded_length(&self) -> u32 {
@@ -23,10 +20,10 @@ impl Encodable for KeepAlive {
 }
 
 impl Decodable for KeepAlive {
-    type Err = VariableHeaderError;
+    type Error = VariableHeaderError;
     type Cond = ();
 
-    fn decode_with<R: Read>(reader: &mut R, _rest: Option<()>) -> Result<KeepAlive, VariableHeaderError> {
+    fn decode_with<R: Read>(reader: &mut R, _rest: ()) -> Result<KeepAlive, VariableHeaderError> {
         reader.read_u16::<BigEndian>().map(KeepAlive).map_err(From::from)
     }
 }

--- a/src/control/variable_header/mod.rs
+++ b/src/control/variable_header/mod.rs
@@ -1,13 +1,9 @@
 //! Variable header in MQTT
 
-use std::convert::From;
-use std::error::Error;
-use std::fmt;
 use std::io;
 use std::string::FromUtf8Error;
 
-use crate::encodable::StringEncodeError;
-use crate::topic_name::TopicNameError;
+use crate::topic_name::{TopicNameDecodeError, TopicNameError};
 
 pub use self::connect_ack_flags::ConnackFlags;
 pub use self::connect_flags::ConnectFlags;
@@ -28,62 +24,25 @@ mod protocol_name;
 mod topic_name;
 
 /// Errors while decoding variable header
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum VariableHeaderError {
-    IoError(io::Error),
-    StringEncodeError(StringEncodeError),
+    #[error(transparent)]
+    IoError(#[from] io::Error),
+    #[error("invalid reserved flags")]
     InvalidReservedFlag,
-    FromUtf8Error(FromUtf8Error),
-    TopicNameError(TopicNameError),
+    #[error(transparent)]
+    FromUtf8Error(#[from] FromUtf8Error),
+    #[error(transparent)]
+    TopicNameError(#[from] TopicNameError),
+    #[error("invalid protocol version")]
     InvalidProtocolVersion,
 }
 
-impl From<io::Error> for VariableHeaderError {
-    fn from(err: io::Error) -> VariableHeaderError {
-        VariableHeaderError::IoError(err)
-    }
-}
-
-impl From<FromUtf8Error> for VariableHeaderError {
-    fn from(err: FromUtf8Error) -> VariableHeaderError {
-        VariableHeaderError::FromUtf8Error(err)
-    }
-}
-
-impl From<StringEncodeError> for VariableHeaderError {
-    fn from(err: StringEncodeError) -> VariableHeaderError {
-        VariableHeaderError::StringEncodeError(err)
-    }
-}
-
-impl From<TopicNameError> for VariableHeaderError {
-    fn from(err: TopicNameError) -> VariableHeaderError {
-        VariableHeaderError::TopicNameError(err)
-    }
-}
-
-impl fmt::Display for VariableHeaderError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            VariableHeaderError::IoError(ref err) => write!(f, "{}", err),
-            VariableHeaderError::StringEncodeError(ref err) => write!(f, "{}", err),
-            VariableHeaderError::InvalidReservedFlag => write!(f, "Invalid reserved flags"),
-            VariableHeaderError::FromUtf8Error(ref err) => write!(f, "{}", err),
-            VariableHeaderError::TopicNameError(ref err) => write!(f, "{}", err),
-            VariableHeaderError::InvalidProtocolVersion => write!(f, "Invalid protocol version"),
-        }
-    }
-}
-
-impl Error for VariableHeaderError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match *self {
-            VariableHeaderError::IoError(ref err) => Some(err),
-            VariableHeaderError::StringEncodeError(ref err) => Some(err),
-            VariableHeaderError::InvalidReservedFlag => None,
-            VariableHeaderError::FromUtf8Error(ref err) => Some(err),
-            VariableHeaderError::TopicNameError(ref err) => Some(err),
-            VariableHeaderError::InvalidProtocolVersion => None,
+impl From<TopicNameDecodeError> for VariableHeaderError {
+    fn from(err: TopicNameDecodeError) -> VariableHeaderError {
+        match err {
+            TopicNameDecodeError::IoError(e) => Self::IoError(e),
+            TopicNameDecodeError::InvalidTopicName(e) => Self::TopicNameError(e),
         }
     }
 }

--- a/src/control/variable_header/packet_identifier.rs
+++ b/src/control/variable_header/packet_identifier.rs
@@ -1,5 +1,4 @@
-use std::convert::From;
-use std::io::{Read, Write};
+use std::io::{self, Read, Write};
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
@@ -11,10 +10,8 @@ use crate::{Decodable, Encodable};
 pub struct PacketIdentifier(pub u16);
 
 impl Encodable for PacketIdentifier {
-    type Err = VariableHeaderError;
-
-    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), VariableHeaderError> {
-        writer.write_u16::<BigEndian>(self.0).map_err(From::from)
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
+        writer.write_u16::<BigEndian>(self.0)
     }
 
     fn encoded_length(&self) -> u32 {
@@ -23,10 +20,10 @@ impl Encodable for PacketIdentifier {
 }
 
 impl Decodable for PacketIdentifier {
-    type Err = VariableHeaderError;
+    type Error = VariableHeaderError;
     type Cond = ();
 
-    fn decode_with<R: Read>(reader: &mut R, _rest: Option<()>) -> Result<PacketIdentifier, VariableHeaderError> {
+    fn decode_with<R: Read>(reader: &mut R, _rest: ()) -> Result<PacketIdentifier, VariableHeaderError> {
         reader.read_u16::<BigEndian>().map(PacketIdentifier).map_err(From::from)
     }
 }

--- a/src/control/variable_header/protocol_level.rs
+++ b/src/control/variable_header/protocol_level.rs
@@ -1,7 +1,6 @@
 //! Protocol level header
 
-use std::convert::From;
-use std::io::{Read, Write};
+use std::io::{self, Read, Write};
 
 use byteorder::{ReadBytesExt, WriteBytesExt};
 
@@ -22,10 +21,8 @@ pub enum ProtocolLevel {
 }
 
 impl Encodable for ProtocolLevel {
-    type Err = VariableHeaderError;
-
-    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), VariableHeaderError> {
-        writer.write_u8(*self as u8).map_err(From::from)
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
+        writer.write_u8(*self as u8)
     }
 
     fn encoded_length(&self) -> u32 {
@@ -34,10 +31,10 @@ impl Encodable for ProtocolLevel {
 }
 
 impl Decodable for ProtocolLevel {
-    type Err = VariableHeaderError;
+    type Error = VariableHeaderError;
     type Cond = ();
 
-    fn decode_with<R: Read>(reader: &mut R, _rest: Option<()>) -> Result<ProtocolLevel, VariableHeaderError> {
+    fn decode_with<R: Read>(reader: &mut R, _rest: ()) -> Result<ProtocolLevel, VariableHeaderError> {
         reader
             .read_u8()
             .map_err(From::from)

--- a/src/control/variable_header/protocol_name.rs
+++ b/src/control/variable_header/protocol_name.rs
@@ -1,5 +1,4 @@
-use std::convert::From;
-use std::io::{Read, Write};
+use std::io::{self, Read, Write};
 
 use crate::control::variable_header::VariableHeaderError;
 use crate::{Decodable, Encodable};
@@ -23,10 +22,8 @@ use crate::{Decodable, Encodable};
 pub struct ProtocolName(pub String);
 
 impl Encodable for ProtocolName {
-    type Err = VariableHeaderError;
-
-    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), VariableHeaderError> {
-        (&self.0[..]).encode(writer).map_err(From::from)
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
+        (&self.0[..]).encode(writer)
     }
 
     fn encoded_length(&self) -> u32 {
@@ -35,10 +32,10 @@ impl Encodable for ProtocolName {
 }
 
 impl Decodable for ProtocolName {
-    type Err = VariableHeaderError;
+    type Error = VariableHeaderError;
     type Cond = ();
 
-    fn decode_with<R: Read>(reader: &mut R, _rest: Option<()>) -> Result<ProtocolName, VariableHeaderError> {
+    fn decode_with<R: Read>(reader: &mut R, _rest: ()) -> Result<ProtocolName, VariableHeaderError> {
         Ok(ProtocolName(Decodable::decode(reader)?))
     }
 }

--- a/src/control/variable_header/topic_name.rs
+++ b/src/control/variable_header/topic_name.rs
@@ -1,5 +1,4 @@
-use std::convert::{From, Into};
-use std::io::{Read, Write};
+use std::io::{self, Read, Write};
 
 use crate::control::variable_header::VariableHeaderError;
 use crate::topic_name::TopicName;
@@ -25,10 +24,8 @@ impl Into<TopicName> for TopicNameHeader {
 }
 
 impl Encodable for TopicNameHeader {
-    type Err = VariableHeaderError;
-
-    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), VariableHeaderError> {
-        (&self.0[..]).encode(writer).map_err(From::from)
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
+        (&self.0[..]).encode(writer)
     }
 
     fn encoded_length(&self) -> u32 {
@@ -37,10 +34,10 @@ impl Encodable for TopicNameHeader {
 }
 
 impl Decodable for TopicNameHeader {
-    type Err = VariableHeaderError;
+    type Error = VariableHeaderError;
     type Cond = ();
 
-    fn decode_with<R: Read>(reader: &mut R, _rest: Option<()>) -> Result<TopicNameHeader, VariableHeaderError> {
+    fn decode_with<R: Read>(reader: &mut R, _rest: ()) -> Result<TopicNameHeader, VariableHeaderError> {
         TopicNameHeader::new(Decodable::decode(reader)?)
     }
 }

--- a/src/encodable.rs
+++ b/src/encodable.rs
@@ -1,49 +1,67 @@
 //! Encodable traits
 
-use std::convert::{From, Infallible};
+use std::convert::Infallible;
 use std::error::Error;
-use std::fmt;
+
 use std::io::{self, Read, Write};
 use std::marker::Sized;
-use std::string::FromUtf8Error;
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
 /// Methods for encoding an Object to bytes according to MQTT specification
 pub trait Encodable {
-    type Err: Error;
-
     /// Encodes to writer
-    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Self::Err>;
+    fn encode<W: Write>(&self, writer: &mut W) -> io::Result<()>;
     /// Length of bytes after encoded
     fn encoded_length(&self) -> u32;
 }
 
+impl<T: Encodable> Encodable for &T {
+    fn encode<W: Write>(&self, writer: &mut W) -> io::Result<()> {
+        (**self).encode(writer)
+    }
+    fn encoded_length(&self) -> u32 {
+        (**self).encoded_length()
+    }
+}
+
+impl<T: Encodable> Encodable for Option<T> {
+    fn encode<W: Write>(&self, writer: &mut W) -> io::Result<()> {
+        if let Some(this) = self {
+            this.encode(writer)?
+        }
+        Ok(())
+    }
+
+    fn encoded_length(&self) -> u32 {
+        self.as_ref().map_or(0, |x| x.encoded_length())
+    }
+}
+
 /// Methods for decoding bytes to an Object according to MQTT specification
 pub trait Decodable: Sized {
-    type Err: Error;
+    type Error: Error;
     type Cond;
 
     /// Decodes object from reader
-    fn decode<R: Read>(reader: &mut R) -> Result<Self, Self::Err> {
-        Self::decode_with(reader, None)
+    fn decode<R: Read>(reader: &mut R) -> Result<Self, Self::Error>
+    where
+        Self::Cond: Default,
+    {
+        Self::decode_with(reader, Default::default())
     }
 
     /// Decodes object with additional data (or hints)
-    fn decode_with<R: Read>(reader: &mut R, cond: Option<Self::Cond>) -> Result<Self, Self::Err>;
+    fn decode_with<R: Read>(reader: &mut R, cond: Self::Cond) -> Result<Self, Self::Error>;
 }
 
 impl<'a> Encodable for &'a str {
-    type Err = StringEncodeError;
-
-    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), StringEncodeError> {
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
         assert!(self.as_bytes().len() <= u16::max_value() as usize);
 
         writer
             .write_u16::<BigEndian>(self.as_bytes().len() as u16)
-            .map_err(From::from)
             .and_then(|_| writer.write_all(self.as_bytes()))
-            .map_err(StringEncodeError::IoError)
     }
 
     fn encoded_length(&self) -> u32 {
@@ -52,8 +70,6 @@ impl<'a> Encodable for &'a str {
 }
 
 impl<'a> Encodable for &'a [u8] {
-    type Err = io::Error;
-
     fn encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
         writer.write_all(self)
     }
@@ -64,9 +80,7 @@ impl<'a> Encodable for &'a [u8] {
 }
 
 impl Encodable for String {
-    type Err = StringEncodeError;
-
-    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), StringEncodeError> {
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
         (&self[..]).encode(writer)
     }
 
@@ -76,24 +90,17 @@ impl Encodable for String {
 }
 
 impl Decodable for String {
-    type Err = StringEncodeError;
+    type Error = io::Error;
     type Cond = ();
 
-    fn decode_with<R: Read>(reader: &mut R, _rest: Option<()>) -> Result<String, StringEncodeError> {
-        let len = reader.read_u16::<BigEndian>()? as usize;
-        let mut buf = Vec::with_capacity(len);
-        unsafe {
-            buf.set_len(len);
-        }
-        reader.read_exact(&mut buf)?;
+    fn decode_with<R: Read>(reader: &mut R, _rest: ()) -> Result<String, io::Error> {
+        let VarBytes(buf) = VarBytes::decode(reader)?;
 
-        String::from_utf8(buf).map_err(StringEncodeError::FromUtf8Error)
+        String::from_utf8(buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
     }
 }
 
 impl Encodable for Vec<u8> {
-    type Err = io::Error;
-
     fn encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
         (&self[..]).encode(writer)
     }
@@ -104,17 +111,14 @@ impl Encodable for Vec<u8> {
 }
 
 impl Decodable for Vec<u8> {
-    type Err = io::Error;
-    type Cond = u32;
+    type Error = io::Error;
+    type Cond = Option<u32>;
 
     fn decode_with<R: Read>(reader: &mut R, length: Option<u32>) -> Result<Vec<u8>, io::Error> {
         match length {
             Some(length) => {
                 let mut buf = Vec::with_capacity(length as usize);
-                unsafe {
-                    buf.set_len(length as usize);
-                }
-                reader.read_exact(&mut buf)?;
+                reader.take(length.into()).read_to_end(&mut buf)?;
                 Ok(buf)
             }
             None => {
@@ -127,9 +131,7 @@ impl Decodable for Vec<u8> {
 }
 
 impl Encodable for () {
-    type Err = Infallible;
-
-    fn encode<W: Write>(&self, _: &mut W) -> Result<(), Self::Err> {
+    fn encode<W: Write>(&self, _: &mut W) -> Result<(), io::Error> {
         Ok(())
     }
 
@@ -139,10 +141,10 @@ impl Encodable for () {
 }
 
 impl Decodable for () {
-    type Err = Infallible;
+    type Error = Infallible;
     type Cond = ();
 
-    fn decode_with<R: Read>(_: &mut R, _: Option<()>) -> Result<(), Self::Err> {
+    fn decode_with<R: Read>(_: &mut R, _: ()) -> Result<(), Self::Error> {
         Ok(())
     }
 }
@@ -152,8 +154,7 @@ impl Decodable for () {
 pub struct VarBytes(pub Vec<u8>);
 
 impl Encodable for VarBytes {
-    type Err = io::Error;
-    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Self::Err> {
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
         assert!(self.0.len() <= u16::max_value() as usize);
         let len = self.0.len() as u16;
         writer.write_u16::<BigEndian>(len)?;
@@ -167,56 +168,13 @@ impl Encodable for VarBytes {
 }
 
 impl Decodable for VarBytes {
-    type Err = io::Error;
+    type Error = io::Error;
     type Cond = ();
-    fn decode_with<R: Read>(reader: &mut R, _: Option<()>) -> Result<VarBytes, io::Error> {
-        let length = reader.read_u16::<BigEndian>()? as usize;
-        let mut buf = Vec::with_capacity(length);
-        unsafe {
-            buf.set_len(length);
-        }
-        reader.read_exact(&mut buf)?;
+    fn decode_with<R: Read>(reader: &mut R, _: ()) -> Result<VarBytes, io::Error> {
+        let length = reader.read_u16::<BigEndian>()?;
+        let mut buf = Vec::with_capacity(length as usize);
+        reader.take(length.into()).read_to_end(&mut buf)?;
         Ok(VarBytes(buf))
-    }
-}
-
-/// Errors while parsing to a string
-#[derive(Debug)]
-pub enum StringEncodeError {
-    IoError(io::Error),
-    FromUtf8Error(FromUtf8Error),
-    MalformedData,
-}
-
-impl fmt::Display for StringEncodeError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            StringEncodeError::IoError(ref err) => err.fmt(f),
-            StringEncodeError::FromUtf8Error(ref err) => err.fmt(f),
-            StringEncodeError::MalformedData => write!(f, "Malformed data"),
-        }
-    }
-}
-
-impl Error for StringEncodeError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match *self {
-            StringEncodeError::IoError(ref err) => Some(err),
-            StringEncodeError::FromUtf8Error(ref err) => Some(err),
-            StringEncodeError::MalformedData => None,
-        }
-    }
-}
-
-impl From<io::Error> for StringEncodeError {
-    fn from(err: io::Error) -> StringEncodeError {
-        StringEncodeError::IoError(err)
-    }
-}
-
-impl From<FromUtf8Error> for StringEncodeError {
-    fn from(err: FromUtf8Error) -> StringEncodeError {
-        StringEncodeError::FromUtf8Error(err)
     }
 }
 

--- a/src/packet/connack.rs
+++ b/src/packet/connack.rs
@@ -1,11 +1,11 @@
 //! CONNACK
 
-use std::io::{Read, Write};
+use std::io::Read;
 
 use crate::control::variable_header::{ConnackFlags, ConnectReturnCode};
 use crate::control::{ControlType, FixedHeader, PacketType};
 use crate::packet::{Packet, PacketError};
-use crate::{Decodable, Encodable};
+use crate::Decodable;
 
 /// `CONNACK` packet
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -15,6 +15,8 @@ pub struct ConnackPacket {
     ret_code: ConnectReturnCode,
     payload: (),
 }
+
+encodable_packet!(ConnackPacket(flags, ret_code));
 
 impl ConnackPacket {
     pub fn new(session_present: bool, ret_code: ConnectReturnCode) -> ConnackPacket {
@@ -38,26 +40,12 @@ impl ConnackPacket {
 impl Packet for ConnackPacket {
     type Payload = ();
 
-    fn fixed_header(&self) -> &FixedHeader {
-        &self.fixed_header
-    }
-
     fn payload(self) -> Self::Payload {
         self.payload
     }
 
     fn payload_ref(&self) -> &Self::Payload {
         &self.payload
-    }
-
-    fn encode_variable_headers<W: Write>(&self, writer: &mut W) -> Result<(), PacketError<Self>> {
-        self.flags.encode(writer)?;
-        self.ret_code.encode(writer)?;
-        Ok(())
-    }
-
-    fn encoded_variable_headers_length(&self) -> u32 {
-        self.flags.encoded_length() + self.ret_code.encoded_length()
     }
 
     fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {

--- a/src/packet/disconnect.rs
+++ b/src/packet/disconnect.rs
@@ -1,6 +1,6 @@
 //! DISCONNECT
 
-use std::io::{Read, Write};
+use std::io::Read;
 
 use crate::control::{ControlType, FixedHeader, PacketType};
 use crate::packet::{Packet, PacketError};
@@ -11,6 +11,8 @@ pub struct DisconnectPacket {
     fixed_header: FixedHeader,
     payload: (),
 }
+
+encodable_packet!(DisconnectPacket());
 
 impl DisconnectPacket {
     pub fn new() -> DisconnectPacket {
@@ -30,24 +32,12 @@ impl Default for DisconnectPacket {
 impl Packet for DisconnectPacket {
     type Payload = ();
 
-    fn fixed_header(&self) -> &FixedHeader {
-        &self.fixed_header
-    }
-
     fn payload(self) -> Self::Payload {
         self.payload
     }
 
     fn payload_ref(&self) -> &Self::Payload {
         &self.payload
-    }
-
-    fn encode_variable_headers<W: Write>(&self, _writer: &mut W) -> Result<(), PacketError<Self>> {
-        Ok(())
-    }
-
-    fn encoded_variable_headers_length(&self) -> u32 {
-        0
     }
 
     fn decode_packet<R: Read>(_reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {

--- a/src/packet/pingreq.rs
+++ b/src/packet/pingreq.rs
@@ -1,6 +1,6 @@
 //! PINGREQ
 
-use std::io::{Read, Write};
+use std::io::Read;
 
 use crate::control::{ControlType, FixedHeader, PacketType};
 use crate::packet::{Packet, PacketError};
@@ -11,6 +11,8 @@ pub struct PingreqPacket {
     fixed_header: FixedHeader,
     payload: (),
 }
+
+encodable_packet!(PingreqPacket());
 
 impl PingreqPacket {
     pub fn new() -> PingreqPacket {
@@ -30,24 +32,12 @@ impl Default for PingreqPacket {
 impl Packet for PingreqPacket {
     type Payload = ();
 
-    fn fixed_header(&self) -> &FixedHeader {
-        &self.fixed_header
-    }
-
     fn payload(self) -> Self::Payload {
         self.payload
     }
 
     fn payload_ref(&self) -> &Self::Payload {
         &self.payload
-    }
-
-    fn encode_variable_headers<W: Write>(&self, _writer: &mut W) -> Result<(), PacketError<Self>> {
-        Ok(())
-    }
-
-    fn encoded_variable_headers_length(&self) -> u32 {
-        0
     }
 
     fn decode_packet<R: Read>(_reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {

--- a/src/packet/pingresp.rs
+++ b/src/packet/pingresp.rs
@@ -1,6 +1,6 @@
 //! PINGRESP
 
-use std::io::{Read, Write};
+use std::io::Read;
 
 use crate::control::{ControlType, FixedHeader, PacketType};
 use crate::packet::{Packet, PacketError};
@@ -11,6 +11,8 @@ pub struct PingrespPacket {
     fixed_header: FixedHeader,
     payload: (),
 }
+
+encodable_packet!(PingrespPacket());
 
 impl PingrespPacket {
     pub fn new() -> PingrespPacket {
@@ -30,24 +32,12 @@ impl Default for PingrespPacket {
 impl Packet for PingrespPacket {
     type Payload = ();
 
-    fn fixed_header(&self) -> &FixedHeader {
-        &self.fixed_header
-    }
-
     fn payload(self) -> Self::Payload {
         self.payload
     }
 
     fn payload_ref(&self) -> &Self::Payload {
         &self.payload
-    }
-
-    fn encode_variable_headers<W: Write>(&self, _writer: &mut W) -> Result<(), PacketError<Self>> {
-        Ok(())
-    }
-
-    fn encoded_variable_headers_length(&self) -> u32 {
-        0
     }
 
     fn decode_packet<R: Read>(_reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {

--- a/src/packet/puback.rs
+++ b/src/packet/puback.rs
@@ -1,11 +1,11 @@
 //! PUBACK
 
-use std::io::{Read, Write};
+use std::io::Read;
 
 use crate::control::variable_header::PacketIdentifier;
 use crate::control::{ControlType, FixedHeader, PacketType};
 use crate::packet::{Packet, PacketError};
-use crate::{Decodable, Encodable};
+use crate::Decodable;
 
 /// `PUBACK` packet
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -14,6 +14,8 @@ pub struct PubackPacket {
     packet_identifier: PacketIdentifier,
     payload: (),
 }
+
+encodable_packet!(PubackPacket(packet_identifier));
 
 impl PubackPacket {
     pub fn new(pkid: u16) -> PubackPacket {
@@ -36,26 +38,12 @@ impl PubackPacket {
 impl Packet for PubackPacket {
     type Payload = ();
 
-    fn fixed_header(&self) -> &FixedHeader {
-        &self.fixed_header
-    }
-
     fn payload(self) -> Self::Payload {
         self.payload
     }
 
     fn payload_ref(&self) -> &Self::Payload {
         &self.payload
-    }
-
-    fn encode_variable_headers<W: Write>(&self, writer: &mut W) -> Result<(), PacketError<Self>> {
-        self.packet_identifier.encode(writer)?;
-
-        Ok(())
-    }
-
-    fn encoded_variable_headers_length(&self) -> u32 {
-        self.packet_identifier.encoded_length()
     }
 
     fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {

--- a/src/packet/pubcomp.rs
+++ b/src/packet/pubcomp.rs
@@ -1,11 +1,11 @@
 //! PUBCOMP
 
-use std::io::{Read, Write};
+use std::io::Read;
 
 use crate::control::variable_header::PacketIdentifier;
 use crate::control::{ControlType, FixedHeader, PacketType};
 use crate::packet::{Packet, PacketError};
-use crate::{Decodable, Encodable};
+use crate::Decodable;
 
 /// `PUBCOMP` packet
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -14,6 +14,8 @@ pub struct PubcompPacket {
     packet_identifier: PacketIdentifier,
     payload: (),
 }
+
+encodable_packet!(PubcompPacket(packet_identifier));
 
 impl PubcompPacket {
     pub fn new(pkid: u16) -> PubcompPacket {
@@ -36,26 +38,12 @@ impl PubcompPacket {
 impl Packet for PubcompPacket {
     type Payload = ();
 
-    fn fixed_header(&self) -> &FixedHeader {
-        &self.fixed_header
-    }
-
     fn payload(self) -> Self::Payload {
         self.payload
     }
 
     fn payload_ref(&self) -> &Self::Payload {
         &self.payload
-    }
-
-    fn encode_variable_headers<W: Write>(&self, writer: &mut W) -> Result<(), PacketError<Self>> {
-        self.packet_identifier.encode(writer)?;
-
-        Ok(())
-    }
-
-    fn encoded_variable_headers_length(&self) -> u32 {
-        self.packet_identifier.encoded_length()
     }
 
     fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {

--- a/src/packet/pubrec.rs
+++ b/src/packet/pubrec.rs
@@ -1,11 +1,11 @@
 //! PUBREC
 
-use std::io::{Read, Write};
+use std::io::Read;
 
 use crate::control::variable_header::PacketIdentifier;
 use crate::control::{ControlType, FixedHeader, PacketType};
 use crate::packet::{Packet, PacketError};
-use crate::{Decodable, Encodable};
+use crate::Decodable;
 
 /// `PUBREC` packet
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -14,6 +14,8 @@ pub struct PubrecPacket {
     packet_identifier: PacketIdentifier,
     payload: (),
 }
+
+encodable_packet!(PubrecPacket(packet_identifier));
 
 impl PubrecPacket {
     pub fn new(pkid: u16) -> PubrecPacket {
@@ -36,26 +38,12 @@ impl PubrecPacket {
 impl Packet for PubrecPacket {
     type Payload = ();
 
-    fn fixed_header(&self) -> &FixedHeader {
-        &self.fixed_header
-    }
-
     fn payload(self) -> Self::Payload {
         self.payload
     }
 
     fn payload_ref(&self) -> &Self::Payload {
         &self.payload
-    }
-
-    fn encode_variable_headers<W: Write>(&self, writer: &mut W) -> Result<(), PacketError<Self>> {
-        self.packet_identifier.encode(writer)?;
-
-        Ok(())
-    }
-
-    fn encoded_variable_headers_length(&self) -> u32 {
-        self.packet_identifier.encoded_length()
     }
 
     fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {

--- a/src/packet/pubrel.rs
+++ b/src/packet/pubrel.rs
@@ -1,11 +1,11 @@
 //! PUBREL
 
-use std::io::{Read, Write};
+use std::io::Read;
 
 use crate::control::variable_header::PacketIdentifier;
 use crate::control::{ControlType, FixedHeader, PacketType};
 use crate::packet::{Packet, PacketError};
-use crate::{Decodable, Encodable};
+use crate::Decodable;
 
 /// `PUBREL` packet
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -14,6 +14,8 @@ pub struct PubrelPacket {
     packet_identifier: PacketIdentifier,
     payload: (),
 }
+
+encodable_packet!(PubrelPacket(packet_identifier));
 
 impl PubrelPacket {
     pub fn new(pkid: u16) -> PubrelPacket {
@@ -36,26 +38,12 @@ impl PubrelPacket {
 impl Packet for PubrelPacket {
     type Payload = ();
 
-    fn fixed_header(&self) -> &FixedHeader {
-        &self.fixed_header
-    }
-
     fn payload(self) -> Self::Payload {
         self.payload
     }
 
     fn payload_ref(&self) -> &Self::Payload {
         &self.payload
-    }
-
-    fn encode_variable_headers<W: Write>(&self, writer: &mut W) -> Result<(), PacketError<Self>> {
-        self.packet_identifier.encode(writer)?;
-
-        Ok(())
-    }
-
-    fn encoded_variable_headers_length(&self) -> u32 {
-        self.packet_identifier.encoded_length()
     }
 
     fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {

--- a/src/packet/unsuback.rs
+++ b/src/packet/unsuback.rs
@@ -1,11 +1,11 @@
 //! UNSUBACK
 
-use std::io::{Read, Write};
+use std::io::Read;
 
 use crate::control::variable_header::PacketIdentifier;
 use crate::control::{ControlType, FixedHeader, PacketType};
 use crate::packet::{Packet, PacketError};
-use crate::{Decodable, Encodable};
+use crate::Decodable;
 
 /// `UNSUBACK` packet
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -14,6 +14,8 @@ pub struct UnsubackPacket {
     packet_identifier: PacketIdentifier,
     payload: (),
 }
+
+encodable_packet!(UnsubackPacket(packet_identifier));
 
 impl UnsubackPacket {
     pub fn new(pkid: u16) -> UnsubackPacket {
@@ -36,26 +38,12 @@ impl UnsubackPacket {
 impl Packet for UnsubackPacket {
     type Payload = ();
 
-    fn fixed_header(&self) -> &FixedHeader {
-        &self.fixed_header
-    }
-
     fn payload(self) -> Self::Payload {
         self.payload
     }
 
     fn payload_ref(&self) -> &Self::Payload {
         &self.payload
-    }
-
-    fn encode_variable_headers<W: Write>(&self, writer: &mut W) -> Result<(), PacketError<Self>> {
-        self.packet_identifier.encode(writer)?;
-
-        Ok(())
-    }
-
-    fn encoded_variable_headers_length(&self) -> u32 {
-        self.packet_identifier.encoded_length()
     }
 
     fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {


### PR DESCRIPTION
(and some other stuff too)

Let me know if there's anything that you'd prefer the old way, but here's what I changed:

- Encodable always returns an error type of `io::Error`, since nothing ever had
  an error that wasn't just the specific error enum's IoError variant
- `Decodable::decode_with` takes `cond: Self::Cond` instead of
  `cond: Option<Self::Cond>`, since a couple seemed to always require the
  argument anyway, and you can still have the behavior before with a default
  function `fn decode() where Self::Cond: Default`
- `Packet` requires `Encodable` rather than a blanket
  `impl<T: Packet> Encodable for Packet` - this let me
  `impl<T: Encodable> Encodable for &T`, which is something I feel makes sense,
  and there's still not a ton of boilerplate since I used a macro.
- Use `derive(thiserror::Error)` for all the error types -- this cuts down on a
  ton of boilerplate, and has the exact same functionality as before.
- Removed `StringDecodeError` and just used a custom `io::Error` instead - I
  feel this reduces some complexity with juggling a bunch of error types, and
  the standard library does that for
  `fs::read_to_string`/`io::Read::read_to_string`. But, a utf8 error really
  isn't an IO error in the more semantic sense, so I'm more unsure of this
  change.

Also renamed `Mqtt{Encode,Decode}Codec` to just `Mqtt{Encoder,Decoder}`, since Codec is a portmanteau of en(co)de/(dec)ode anyway.
