### PR TITLE
Remove the concept of packet payloads from the public API

### DIFF
--- a/src/packet/connack.rs
+++ b/src/packet/connack.rs
@@ -36,7 +36,7 @@ impl ConnackPacket {
 }
 
 impl DecodablePacket for ConnackPacket {
-    type Payload = ();
+    type DecodePacketError = std::convert::Infallible;
 
     fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {
         let flags: ConnackFlags = Decodable::decode(reader)?;

--- a/src/packet/disconnect.rs
+++ b/src/packet/disconnect.rs
@@ -28,7 +28,7 @@ impl Default for DisconnectPacket {
 }
 
 impl DecodablePacket for DisconnectPacket {
-    type Payload = ();
+    type DecodePacketError = std::convert::Infallible;
 
     fn decode_packet<R: Read>(_reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {
         Ok(DisconnectPacket { fixed_header })

--- a/src/packet/pingreq.rs
+++ b/src/packet/pingreq.rs
@@ -28,7 +28,7 @@ impl Default for PingreqPacket {
 }
 
 impl DecodablePacket for PingreqPacket {
-    type Payload = ();
+    type DecodePacketError = std::convert::Infallible;
 
     fn decode_packet<R: Read>(_reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {
         Ok(PingreqPacket { fixed_header })

--- a/src/packet/pingresp.rs
+++ b/src/packet/pingresp.rs
@@ -28,7 +28,7 @@ impl Default for PingrespPacket {
 }
 
 impl DecodablePacket for PingrespPacket {
-    type Payload = ();
+    type DecodePacketError = std::convert::Infallible;
 
     fn decode_packet<R: Read>(_reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {
         Ok(PingrespPacket { fixed_header })

--- a/src/packet/puback.rs
+++ b/src/packet/puback.rs
@@ -34,7 +34,7 @@ impl PubackPacket {
 }
 
 impl DecodablePacket for PubackPacket {
-    type Payload = ();
+    type DecodePacketError = std::convert::Infallible;
 
     fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {
         let packet_identifier: PacketIdentifier = PacketIdentifier::decode(reader)?;

--- a/src/packet/pubcomp.rs
+++ b/src/packet/pubcomp.rs
@@ -34,7 +34,7 @@ impl PubcompPacket {
 }
 
 impl DecodablePacket for PubcompPacket {
-    type Payload = ();
+    type DecodePacketError = std::convert::Infallible;
 
     fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {
         let packet_identifier: PacketIdentifier = PacketIdentifier::decode(reader)?;

--- a/src/packet/publish.rs
+++ b/src/packet/publish.rs
@@ -119,7 +119,7 @@ impl PublishPacket {
 }
 
 impl DecodablePacket for PublishPacket {
-    type Payload = Vec<u8>;
+    type DecodePacketError = std::convert::Infallible;
 
     fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {
         let topic_name = TopicName::decode(reader)?;

--- a/src/packet/pubrec.rs
+++ b/src/packet/pubrec.rs
@@ -34,7 +34,7 @@ impl PubrecPacket {
 }
 
 impl DecodablePacket for PubrecPacket {
-    type Payload = ();
+    type DecodePacketError = std::convert::Infallible;
 
     fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {
         let packet_identifier: PacketIdentifier = PacketIdentifier::decode(reader)?;

--- a/src/packet/pubrel.rs
+++ b/src/packet/pubrel.rs
@@ -34,7 +34,7 @@ impl PubrelPacket {
 }
 
 impl DecodablePacket for PubrelPacket {
-    type Payload = ();
+    type DecodePacketError = std::convert::Infallible;
 
     fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {
         let packet_identifier: PacketIdentifier = PacketIdentifier::decode(reader)?;

--- a/src/packet/unsuback.rs
+++ b/src/packet/unsuback.rs
@@ -34,7 +34,7 @@ impl UnsubackPacket {
 }
 
 impl DecodablePacket for UnsubackPacket {
-    type Payload = ();
+    type DecodePacketError = std::convert::Infallible;
 
     fn decode_packet<R: Read>(reader: &mut R, fixed_header: FixedHeader) -> Result<Self, PacketError<Self>> {
         let packet_identifier: PacketIdentifier = PacketIdentifier::decode(reader)?;


### PR DESCRIPTION
(Except for PublishPacket, of course)

I think this is sorta a continuation of #52; given that there's no Packet trait with payload/payload_ref methods, I think it makes sense to remove the remaining concept of `Payload` types from the EncodePacket trait.
