### PR TITLE
Adding "keep_alive()" function to ConnectPacket

### DIFF
--- a/src/packet/connect.rs
+++ b/src/packet/connect.rs
@@ -131,6 +131,10 @@ impl ConnectPacket {
         self.flags.clean_session
     }
 
+    pub fn keep_alive(&self) -> u16 {
+        self.keep_alive.0
+    }
+
     /// Read back the "reserved" Connect flag bit 0. For compliant implementations this should
     /// always be false.
     pub fn reserved_flag(&self) -> bool {


### PR DESCRIPTION
I am implementing an MQTT broker with this library - it's been great so far, very ergonomic and convenient!  However, I couldn't find a way to retrieve the "KeepAlive" value from an incoming ConnectPacket. I made this small commit to add the functionality to the ConnectPacket implementation.