### PR TITLE
Remove regex dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,6 @@ edition = "2018"
 [dependencies]
 byteorder = "1.3"
 log = "0.4"
-regex = "1.3"
-lazy_static = "1.4"
 tokio = { version = "1", optional = true }
 tokio-util = { version = "0.6", features = ["codec"], optional = true }
 bytes = { version = "1.0", optional = true }

--- a/src/control/packet_type.rs
+++ b/src/control/packet_type.rs
@@ -142,7 +142,7 @@ impl PacketType {
         let type_val = val >> 4;
         let flags = val & 0x0F;
 
-        let control_type = get_control_type(type_val).ok_or_else(|| PacketTypeError::ReservedType(type_val, flags))?;
+        let control_type = get_control_type(type_val).ok_or(PacketTypeError::ReservedType(type_val, flags))?;
         Ok(PacketType::new(control_type, flags)?)
     }
 

--- a/src/control/packet_type.rs
+++ b/src/control/packet_type.rs
@@ -114,7 +114,7 @@ impl PacketType {
 
     /// Creates a packet type with default flags
     ///
-    /// http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Table_2.2_-
+    /// <http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Table_2.2_->
     #[inline]
     pub fn with_default(t: ControlType) -> PacketType {
         let flags = t.default_flags();

--- a/src/control/variable_header/topic_name.rs
+++ b/src/control/variable_header/topic_name.rs
@@ -17,9 +17,9 @@ impl TopicNameHeader {
     }
 }
 
-impl Into<TopicName> for TopicNameHeader {
-    fn into(self) -> TopicName {
-        self.0
+impl From<TopicNameHeader> for TopicName {
+    fn from(hdr: TopicNameHeader) -> Self {
+        hdr.0
     }
 }
 

--- a/src/topic_filter.rs
+++ b/src/topic_filter.rs
@@ -34,7 +34,7 @@ fn is_invalid_topic_filter(topic: &str) -> bool {
 
 /// Topic filter
 ///
-/// http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718106
+/// <http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718106>
 ///
 /// ```rust
 /// use mqtt::{TopicFilter, TopicNameRef};

--- a/src/topic_filter.rs
+++ b/src/topic_filter.rs
@@ -3,21 +3,33 @@
 use std::io::{self, Read, Write};
 use std::ops::Deref;
 
-use lazy_static::lazy_static;
-use regex::Regex;
-
 use crate::topic_name::TopicNameRef;
 use crate::{Decodable, Encodable};
 
-const VALIDATE_TOPIC_FILTER_REGEX: &str = r"^(([^+#]*|\+)(/([^+#]*|\+))*(/#)?|#)$";
-
-lazy_static! {
-    static ref TOPIC_FILTER_VALIDATOR: Regex = Regex::new(VALIDATE_TOPIC_FILTER_REGEX).unwrap();
-}
-
 #[inline]
 fn is_invalid_topic_filter(topic: &str) -> bool {
-    topic.is_empty() || topic.as_bytes().len() > 65535 || !TOPIC_FILTER_VALIDATOR.is_match(&topic)
+    if topic.is_empty() || topic.as_bytes().len() > 65535 {
+        return true;
+    }
+
+    let mut found_hash = false;
+    for member in topic.split('/') {
+        if found_hash {
+            return true;
+        }
+
+        match member {
+            "#" => found_hash = true,
+            "+" => {}
+            _ => {
+                if member.contains(['#', '+']) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    false
 }
 
 /// Topic filter

--- a/src/topic_name.rs
+++ b/src/topic_name.rs
@@ -6,20 +6,11 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use lazy_static::lazy_static;
-use regex::Regex;
-
 use crate::{Decodable, Encodable};
-
-const TOPIC_NAME_VALIDATE_REGEX: &str = r"^[^#+]+$";
-
-lazy_static! {
-    static ref TOPIC_NAME_VALIDATOR: Regex = Regex::new(TOPIC_NAME_VALIDATE_REGEX).unwrap();
-}
 
 #[inline]
 fn is_invalid_topic_name(topic_name: &str) -> bool {
-    topic_name.is_empty() || topic_name.as_bytes().len() > 65535 || !TOPIC_NAME_VALIDATOR.is_match(&topic_name)
+    topic_name.is_empty() || topic_name.as_bytes().len() > 65535 || topic_name.chars().any(|ch| ch == '#' || ch == '+')
 }
 
 /// Topic name

--- a/src/topic_name.rs
+++ b/src/topic_name.rs
@@ -15,7 +15,7 @@ fn is_invalid_topic_name(topic_name: &str) -> bool {
 
 /// Topic name
 ///
-/// http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718106
+/// <http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718106>
 #[derive(Debug, Eq, PartialEq, Clone, Hash, Ord, PartialOrd)]
 pub struct TopicName(String);
 


### PR DESCRIPTION
The immediate reason of removing the `regex` dependency is to reduce the binary size of our application. The gain is around 300K, which is large in the embedded world, where the use of MQTT is a popular choice. The code that used `regex` was reimplemented using constructions from the standard library.

The removal of the crate also has other positive side effects:

- The `lazy_static` crate can also be removed since it's no longer used.
- The less crates you depend on, the less updates you have to apply. For example, the current `regex` version used has a RUSTSEC advisory for.

The change comes with other small commits to fix warnings from `rustdoc` and `cargo clippy` from Rust 1.62.1.